### PR TITLE
Skip ranges of deleted keys in BlockBasedTableIterator

### DIFF
--- a/db/db_range_del_test.cc
+++ b/db/db_range_del_test.cc
@@ -792,6 +792,25 @@ TEST_F(DBRangeDelTest, IteratorIgnoresRangeDeletions) {
   db_->ReleaseSnapshot(snapshot);
 }
 
+TEST_F(DBRangeDelTest, IteratorCoveredSst) {
+  // TODO(peter): generate multiple sstables with some being covered
+  // by tombstones and some that aren't.
+  db_->Put(WriteOptions(), "key", "val");
+  ASSERT_OK(db_->Flush(FlushOptions()));
+  db_->CompactRange(CompactRangeOptions(), nullptr, nullptr);
+  ASSERT_OK(db_->DeleteRange(WriteOptions(), db_->DefaultColumnFamily(), "a", "z"));
+
+  ReadOptions read_opts;
+  auto* iter = db_->NewIterator(read_opts);
+
+  int count = 0;
+  for (iter->SeekToFirst(); iter->Valid(); iter->Next()) {
+    ++count;
+  }
+  ASSERT_EQ(0, count);
+  delete iter;
+}
+
 #ifndef ROCKSDB_UBSAN_RUN
 TEST_F(DBRangeDelTest, TailingIteratorRangeTombstoneUnsupported) {
   db_->Put(WriteOptions(), "key", "val");

--- a/db/range_del_aggregator.h
+++ b/db/range_del_aggregator.h
@@ -92,6 +92,13 @@ class RangeDelAggregator {
   bool ShouldDeleteImpl(const Slice& internal_key,
                         RangePositioningMode mode = kFullScan);
 
+  // Return true if one or more tombstones that are newer than seqno fully
+  // cover the range [start,end] (both endpoints are inclusive). Beware the
+  // inclusive endpoint which differs from most other key ranges, but matches
+  // the largest_key metadata for an sstable.
+  bool ShouldDeleteRange(const Slice& start, const Slice& end,
+                         SequenceNumber seqno);
+
   // Checks whether range deletions cover any keys between `start` and `end`,
   // inclusive.
   //

--- a/db/range_del_aggregator.h
+++ b/db/range_del_aggregator.h
@@ -99,6 +99,13 @@ class RangeDelAggregator {
   bool ShouldDeleteRange(const Slice& start, const Slice& end,
                          SequenceNumber seqno);
 
+  // Get the range tombstone at the specified user_key and sequence number. A
+  // valid tombstone is always returned, though it may cover an empty range of
+  // keys or the sequence number may be 0 to indicate that no tombstone covers
+  // the specified range of keys.
+  RangeTombstone GetTombstone(const Slice& user_key,
+                              SequenceNumber seqno);
+
   // Checks whether range deletions cover any keys between `start` and `end`,
   // inclusive.
   //

--- a/db/range_del_aggregator_test.cc
+++ b/db/range_del_aggregator_test.cc
@@ -111,6 +111,27 @@ bool ShouldDeleteRange(const std::vector<RangeTombstone>& range_dels,
   return range_del_agg.ShouldDeleteRange(begin, end, expected_range.seq);
 }
 
+void VerifyGetTombstone(const std::vector<RangeTombstone>& range_dels,
+                        const ExpectedPoint& expected_point,
+                        const RangeTombstone& expected_tombstone) {
+  auto icmp = InternalKeyComparator(BytewiseComparator());
+  RangeDelAggregator range_del_agg(icmp, {} /* snapshots */, true);
+  std::vector<std::string> keys, values;
+  for (const auto& range_del : range_dels) {
+    auto key_and_value = range_del.Serialize();
+    keys.push_back(key_and_value.first.Encode().ToString());
+    values.push_back(key_and_value.second.ToString());
+  }
+  std::unique_ptr<test::VectorIterator> range_del_iter(
+      new test::VectorIterator(keys, values));
+  range_del_agg.AddTombstones(std::move(range_del_iter));
+
+  auto tombstone = range_del_agg.GetTombstone(expected_point.begin, expected_point.seq);
+  ASSERT_EQ(expected_tombstone.start_key_.ToString(), tombstone.start_key_.ToString());
+  ASSERT_EQ(expected_tombstone.end_key_.ToString(), tombstone.end_key_.ToString());
+  ASSERT_EQ(expected_tombstone.seq_, tombstone.seq_);
+}
+
 }  // anonymous namespace
 
 TEST_F(RangeDelAggregatorTest, Empty) { VerifyRangeDels({}, {{"a", 0}}); }
@@ -235,6 +256,41 @@ TEST_F(RangeDelAggregatorTest, ShouldDeleteRange) {
   ASSERT_FALSE(ShouldDeleteRange(
       {{"a", "b", 10}, {"c", "e", 20}},
       {"c", "d", 20}));
+}
+
+TEST_F(RangeDelAggregatorTest, GetTombstone) {
+  VerifyGetTombstone(
+      {{"b", "d", 10}},
+      {"b", 9},
+      {"b", "d", 10});
+  VerifyGetTombstone(
+      {{"b", "d", 10}},
+      {"b", 20},
+      {"b", "d", 0});
+  VerifyGetTombstone(
+      {{"b", "d", 10}},
+      {"a", 9},
+      {"", "b", 0});
+  VerifyGetTombstone(
+      {{"b", "d", 10}},
+      {"d", 9},
+      {"d", "", 0});
+  VerifyGetTombstone(
+      {{"a", "c", 10}, {"e", "h", 20}},
+      {"d", 9},
+      {"c", "e", 0});
+  VerifyGetTombstone(
+      {{"a", "c", 10}, {"e", "h", 20}},
+      {"b", 9},
+      {"a", "c", 10});
+  VerifyGetTombstone(
+      {{"a", "c", 10}, {"e", "h", 20}},
+      {"e", 9},
+      {"e", "h", 20});
+  VerifyGetTombstone(
+      {{"a", "c", 10}, {"e", "h", 20}},
+      {"e", 9},
+      {"e", "h", 20});
 }
 
 }  // namespace rocksdb

--- a/db/range_del_aggregator_test.cc
+++ b/db/range_del_aggregator_test.cc
@@ -21,6 +21,12 @@ struct ExpectedPoint {
   SequenceNumber seq;
 };
 
+struct ExpectedRange {
+  Slice begin;
+  Slice end;
+  SequenceNumber seq;
+};
+
 enum Direction {
   kForward,
   kReverse,
@@ -83,6 +89,26 @@ void VerifyRangeDels(const std::vector<RangeTombstone>& range_dels,
       ASSERT_FALSE(overlapped);
     }
   }
+}
+
+bool ShouldDeleteRange(const std::vector<RangeTombstone>& range_dels,
+                       const ExpectedRange& expected_range) {
+  auto icmp = InternalKeyComparator(BytewiseComparator());
+  RangeDelAggregator range_del_agg(icmp, {} /* snapshots */, true);
+  std::vector<std::string> keys, values;
+  for (const auto& range_del : range_dels) {
+    auto key_and_value = range_del.Serialize();
+    keys.push_back(key_and_value.first.Encode().ToString());
+    values.push_back(key_and_value.second.ToString());
+  }
+  std::unique_ptr<test::VectorIterator> range_del_iter(
+      new test::VectorIterator(keys, values));
+  range_del_agg.AddTombstones(std::move(range_del_iter));
+
+  std::string begin, end;
+  AppendInternalKey(&begin, {expected_range.begin, expected_range.seq, kTypeValue});
+  AppendInternalKey(&end, {expected_range.end, expected_range.seq, kTypeValue});
+  return range_del_agg.ShouldDeleteRange(begin, end, expected_range.seq);
 }
 
 }  // anonymous namespace
@@ -173,6 +199,42 @@ TEST_F(RangeDelAggregatorTest, AlternateMultipleAboveBelow) {
        {"e", 20},
        {"g", 5},
        {"h", 0}});
+}
+
+TEST_F(RangeDelAggregatorTest, ShouldDeleteRange) {
+  ASSERT_TRUE(ShouldDeleteRange(
+      {{"a", "c", 10}},
+      {"a", "b", 9}));
+  ASSERT_TRUE(ShouldDeleteRange(
+      {{"a", "c", 10}},
+      {"a", "a", 9}));
+  ASSERT_FALSE(ShouldDeleteRange(
+      {{"a", "c", 10}},
+      {"b", "a", 9}));
+  ASSERT_FALSE(ShouldDeleteRange(
+      {{"a", "c", 10}},
+      {"a", "b", 10}));
+  ASSERT_FALSE(ShouldDeleteRange(
+      {{"a", "c", 10}},
+      {"a", "c", 9}));
+  ASSERT_FALSE(ShouldDeleteRange(
+      {{"b", "c", 10}},
+      {"a", "b", 9}));
+  ASSERT_TRUE(ShouldDeleteRange(
+      {{"a", "b", 10}, {"b", "d", 20}},
+      {"a", "c", 9}));
+  ASSERT_FALSE(ShouldDeleteRange(
+      {{"a", "b", 10}, {"b", "d", 20}},
+      {"a", "c", 15}));
+  ASSERT_FALSE(ShouldDeleteRange(
+      {{"a", "b", 10}, {"c", "e", 20}},
+      {"a", "d", 9}));
+  ASSERT_TRUE(ShouldDeleteRange(
+      {{"a", "b", 10}, {"c", "e", 20}},
+      {"c", "d", 15}));
+  ASSERT_FALSE(ShouldDeleteRange(
+      {{"a", "b", 10}, {"c", "e", 20}},
+      {"c", "d", 20}));
 }
 
 }  // namespace rocksdb

--- a/db/table_cache.cc
+++ b/db/table_cache.cc
@@ -229,7 +229,9 @@ InternalIterator* TableCache::NewIterator(
         !options.table_filter(*table_reader->GetTableProperties())) {
       result = NewEmptyInternalIterator(arena);
     } else {
-      result = table_reader->NewIterator(options, arena, skip_filters);
+      result = table_reader->NewIterator(
+          options, range_del_agg, nullptr /* file_meta */,
+          arena, skip_filters);
     }
     if (create_new_table_reader) {
       assert(handle == nullptr);

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -541,8 +541,8 @@ class LevelIterator final : public InternalIterator {
     assert(file_index_ < flevel_->num_files);
     auto file_meta = flevel_->files[file_index_];
     // Check to see if every key in the sstable is covered by a range
-    // tombstone. SkipEmptyFile{Forward,Backward} will take care of
-    // skipping over an "empty" file if we return null.
+    // tombstone. SkipEmptyFile{Forward,Backward} will take care of skipping
+    // over an "empty" file if we return null.
     if (range_del_agg_->ShouldDeleteRange(file_meta.smallest_key, file_meta.largest_key,
                                           file_meta.file_metadata->largest_seqno)) {
       return nullptr;

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -540,6 +540,14 @@ class LevelIterator final : public InternalIterator {
   InternalIterator* NewFileIterator() {
     assert(file_index_ < flevel_->num_files);
     auto file_meta = flevel_->files[file_index_];
+    // Check to see if every key in the sstable is covered by a range
+    // tombstone. SkipEmptyFile{Forward,Backward} will take care of
+    // skipping over an "empty" file if we return null.
+    if (range_del_agg_->ShouldDeleteRange(file_meta.smallest_key, file_meta.largest_key,
+                                          file_meta.file_metadata->largest_seqno)) {
+      return nullptr;
+    }
+
     if (should_sample_) {
       sample_file_read_inc(file_meta.file_metadata);
     }
@@ -574,6 +582,21 @@ void LevelIterator::Seek(const Slice& target) {
 
   InitFileIterator(new_file_index);
   if (file_iter_.iter() != nullptr) {
+    // TODO(peter): Rather the seeking to target, we could use
+    // RangeDelAggregator to find the first key within the file that
+    // is not covered by a range tombstone. Something like:
+    //
+    //   first_non_deleted = range_del_agg_->SeekForward(
+    //       smallest_key, largest_key, largest_seqno);
+    //   if (target < first_non_deleted) {
+    //     target = first_non_deleted;
+    //   }
+    //
+    // This optimization applies to SeekForPrev, Next and Prev as
+    // well. For Next and Prev we'd want some way to keep track of the
+    // current tombstone. Perhaps a RangeDelAggregator::Iterator,
+    // though that would need to be stable in the presence of
+    // modifications to RangeDelAggregator tombstone_maps.
     file_iter_.Seek(target);
   }
   SkipEmptyFileForward();
@@ -588,8 +611,8 @@ void LevelIterator::SeekForPrev(const Slice& target) {
   InitFileIterator(new_file_index);
   if (file_iter_.iter() != nullptr) {
     file_iter_.SeekForPrev(target);
-    SkipEmptyFileBackward();
   }
+  SkipEmptyFileBackward();
 }
 
 void LevelIterator::SeekToFirst() {

--- a/table/block_based_table_reader.cc
+++ b/table/block_based_table_reader.cc
@@ -218,6 +218,7 @@ class PartitionIndexReader : public IndexReader, public Cleanable {
     } else {
       return new BlockBasedTableIterator(
           table_, ReadOptions(), *icomparator_,
+          nullptr /* range_del_agg */, nullptr /* file_meta */,
           index_block_->NewIterator(icomparator_, nullptr, true), false);
     }
     // TODO(myabandeh): Update TwoLevelIterator to be able to make use of
@@ -1770,10 +1771,19 @@ bool BlockBasedTable::PrefixMayMatch(const Slice& internal_key) {
   return may_match;
 }
 
-void BlockBasedTableIterator::Seek(const Slice& target) {
+void BlockBasedTableIterator::Seek(const Slice& const_target) {
+  Slice target(const_target);
   if (!CheckPrefixMayMatch(target)) {
     ResetDataIter();
     return;
+  }
+
+  // Before we seek the iterator, find the next non-deleted key.
+  InitRangeTombstone(ExtractUserKey(target));
+  std::string tmp_target;
+  if (range_tombstone_.seq_ > 0) {
+    tmp_target = tombstone_internal_end_key();
+    target = tmp_target;
   }
 
   SavePrevIndexValue();
@@ -1794,10 +1804,19 @@ void BlockBasedTableIterator::Seek(const Slice& target) {
          icomp_.Compare(target, data_block_iter_.key()) <= 0);
 }
 
-void BlockBasedTableIterator::SeekForPrev(const Slice& target) {
+void BlockBasedTableIterator::SeekForPrev(const Slice& const_target) {
+  Slice target(const_target);
   if (!CheckPrefixMayMatch(target)) {
     ResetDataIter();
     return;
+  }
+
+  // Before we seek the iterator, find the previous non-deleted key.
+  InitRangeTombstone(ExtractUserKey(target));
+  std::string tmp_target;
+  if (range_tombstone_.seq_ > 0) {
+    tmp_target = tombstone_internal_start_key();
+    target = tmp_target;
   }
 
   SavePrevIndexValue();
@@ -1844,6 +1863,9 @@ void BlockBasedTableIterator::SeekToFirst() {
   }
   InitDataBlock();
   data_block_iter_.SeekToFirst();
+  if (Valid()) {
+    InitRangeTombstone(user_key());
+  }
   FindKeyForward();
 }
 
@@ -1856,6 +1878,9 @@ void BlockBasedTableIterator::SeekToLast() {
   }
   InitDataBlock();
   data_block_iter_.SeekToLast();
+  if (Valid()) {
+    InitRangeTombstone(user_key());
+  }
   FindKeyBackward();
 }
 
@@ -1912,72 +1937,208 @@ void BlockBasedTableIterator::InitDataBlock() {
 }
 
 void BlockBasedTableIterator::FindKeyForward() {
+  // FindKeyForward is called when the iterator has already been advanced (via
+  // a call to Seek, SeekToFirst or Next) and we're looking for the next valid
+  // key.
+
   is_out_of_bound_ = false;
-  // TODO the while loop inherits from two-level-iterator. We don't know
-  // whether a block can be empty so it can be replaced by an "if".
-  while (!data_block_iter_.Valid()) {
-    if (!data_block_iter_.status().ok()) {
+  for (;;) {
+    // TODO the while loop inherits from two-level-iterator. We don't know
+    // whether a block can be empty so it can be replaced by an "if".
+    while (!data_block_iter_.Valid()) {
+      if (!data_block_iter_.status().ok()) {
+        return;
+      }
+      ResetDataIter();
+      // We used to check the current index key for upperbound.
+      // It will only save a data reading for a small percentage of use cases,
+      // so for code simplicity, we removed it. We can add it back if there is a
+      // significant performance regression.
+      index_iter_->Next();
+
+      if (index_iter_->Valid()) {
+        InitDataBlock();
+        data_block_iter_.SeekToFirst();
+      } else {
+        return;
+      }
+    }
+
+    if (!Valid()) {
       return;
     }
-    ResetDataIter();
-    // We used to check the current index key for upperbound.
-    // It will only save a data reading for a small percentage of use cases,
-    // so for code simplicity, we removed it. We can add it back if there is a
-    // significnat performance regression.
-    index_iter_->Next();
 
-    if (index_iter_->Valid()) {
-      InitDataBlock();
-      data_block_iter_.SeekToFirst();
-    } else {
+    // Check upper bound on the current key
+    bool reached_upper_bound =
+        (read_options_.iterate_upper_bound != nullptr &&
+         icomp_.user_comparator()->Compare(ExtractUserKey(data_block_iter_.key()),
+                                           *read_options_.iterate_upper_bound) >=
+         0);
+    TEST_SYNC_POINT_CALLBACK(
+        "BlockBasedTable::BlockEntryIteratorState::KeyReachedUpperBound",
+        &reached_upper_bound);
+    if (reached_upper_bound) {
+      is_out_of_bound_ = true;
+    ResetDataIter();
       return;
     }
-  }
 
-  // Check upper bound on the current key
-  bool reached_upper_bound =
-      (read_options_.iterate_upper_bound != nullptr &&
-       block_iter_points_to_real_block_ && data_block_iter_.Valid() &&
-       icomp_.user_comparator()->Compare(ExtractUserKey(data_block_iter_.key()),
-                                         *read_options_.iterate_upper_bound) >=
-           0);
-  TEST_SYNC_POINT_CALLBACK(
-      "BlockBasedTable::BlockEntryIteratorState::KeyReachedUpperBound",
-      &reached_upper_bound);
-  if (reached_upper_bound) {
-    is_out_of_bound_ = true;
-    ResetDataIter();
-    return;
+    // Check to see if data_block_iter_.key() is covered by the current range
+    // tombstone. Note that range_tombstone_ is not a raw range tombstone
+    // returned from RangeDelAggregator, but a cooked one. See
+    // InitRangeTombstone().
+    if (range_tombstone_.end_key_.empty()) {
+      // The range tombstone extends to the end of the sstable.
+      if (range_tombstone_.seq_ == 0) {
+        // The range tombstone doesn't apply to the keys in the sstable. Return
+        // the entry.
+        return;
+      }
+      ResetDataIter();
+      return;
+    }
+
+    auto ukey = user_key();
+    if (icomp_.user_comparator()->Compare(
+            ukey, range_tombstone_.end_key_) >= 0) {
+      // The key is past the tombstone. Grab the tombstone covering the
+      // current key. The new tombstone might cover the existing key, so loop
+      // so that we can have the proper check for whether the tombstone covers
+      // the key and is a deletion tombstone or not.
+      InitRangeTombstone(ukey);
+      continue;
+    }
+    // The key is contained within the current tombstone.
+    if (range_tombstone_.seq_ == 0) {
+      // The tombstone doesn't apply to the sstable. Return the entry.
+      return;
+    }
+
+    // Find the next non-deleted key.
+    index_iter_->Seek(tombstone_internal_end_key());
+    if (!index_iter_->Valid()) {
+      ResetDataIter();
+      return;
+    }
+    InitDataBlock();
+    data_block_iter_.Seek(tombstone_internal_end_key());
+    if (Valid()) {
+      InitRangeTombstone(user_key());
+    }
   }
 }
 
 void BlockBasedTableIterator::FindKeyBackward() {
-  while (!data_block_iter_.Valid()) {
-    if (!data_block_iter_.status().ok()) {
+  // FindKeyBackward is called when the iterator has already been advanced
+  // (via a call to SeekForPrev, SeekToLast or Prev) and we're looking for the
+  // next valid key.
+
+  for (;;) {
+    while (!data_block_iter_.Valid()) {
+      if (!data_block_iter_.status().ok()) {
+        return;
+      }
+
+      ResetDataIter();
+      index_iter_->Prev();
+
+      if (index_iter_->Valid()) {
+        InitDataBlock();
+        data_block_iter_.SeekToLast();
+      } else {
+        return;
+      }
+    }
+
+    if (!Valid()) {
       return;
     }
 
-    ResetDataIter();
-    index_iter_->Prev();
+    // We could have check lower bound here too, but we opt not to do it for
+    // code simplicity.
 
-    if (index_iter_->Valid()) {
-      InitDataBlock();
-      data_block_iter_.SeekToLast();
-    } else {
+    // Check to see if data_block_iter_.key() is covered by the current range
+    // tombstone. Note that range_tombstone_ is not a raw range tombstone
+    // returned from RangeDelAggregator, but a cooked one. See
+    // InitRangeTombstone().
+    if (range_tombstone_.start_key_.empty()) {
+      // The range tombstone extends to the beginning of the sstable.
+      if (range_tombstone_.seq_ == 0) {
+        // The range doesn't apply to the keys in the sstable. Return the
+        // entry.
+        return;
+      }
+      // The range tombstone is a deletion tombstone.
+      ResetDataIter();
       return;
+    }
+
+    auto ukey = user_key();
+    if (icomp_.user_comparator()->Compare(
+            ukey, range_tombstone_.start_key_) < 0) {
+      // The key is past the tombstone. Grab the tombstone covering the
+      // current key. The new tombstone might cover the existing key, so loop
+      // so that we can have the proper check for whether the tombstone covers
+      // the key and is a deletion tombstone or not.
+      InitRangeTombstone(ukey);
+      continue;
+    }
+    // The key is contained within the current tombstone.
+    if (range_tombstone_.seq_ == 0) {
+      // The tombstone doesn't apply to the sstable. Return the entry.
+      return;
+    }
+
+    // Find the previous non-deleted key.
+    index_iter_->Seek(tombstone_internal_start_key());
+    if (!index_iter_->Valid()) {
+      index_iter_->SeekToLast();
+      if (!index_iter_->Valid()) {
+        ResetDataIter();
+        block_iter_points_to_real_block_ = false;
+        return;
+      }
+    }
+    InitDataBlock();
+    data_block_iter_.SeekForPrev(tombstone_internal_end_key());
+    if (Valid()) {
+      InitRangeTombstone(user_key());
     }
   }
-
-  // We could have check lower bound here too, but we opt not to do it for
-  // code simplicity.
 }
 
-InternalIterator* BlockBasedTable::NewIterator(const ReadOptions& read_options,
-                                               Arena* arena,
-                                               bool skip_filters) {
+void BlockBasedTableIterator::InitRangeTombstone(const Slice& target) {
+  if (range_del_agg_ == nullptr || file_meta_ == nullptr) {
+    return;
+  }
+
+  range_tombstone_ = range_del_agg_->GetTombstone(target, file_meta_->largest_seqno);
+  // Clear the start key if it is less than the smallest key in the
+  // sstable. This allows us to avoid comparisons during Prev() in the common
+  // case.
+  if (!range_tombstone_.start_key_.empty() &&
+      icomp_.user_comparator()->Compare(
+          range_tombstone_.start_key_, file_meta_->smallest.user_key()) < 0) {
+    range_tombstone_.start_key_.clear();
+  }
+  // Clear the end key if it is larger than the largest key in the
+  // sstable. This allows us to avoid comparisons during Next() in the common
+  // case.
+  if (!range_tombstone_.end_key_.empty() &&
+      icomp_.user_comparator()->Compare(
+          range_tombstone_.end_key_, file_meta_->largest.user_key()) > 0) {
+    range_tombstone_.end_key_.clear();
+  }
+}
+
+InternalIterator* BlockBasedTable::NewIterator(
+    const ReadOptions& read_options,
+    RangeDelAggregator* range_del_agg, const FileMetaData* file_meta,
+    Arena* arena, bool skip_filters) {
   if (arena == nullptr) {
     return new BlockBasedTableIterator(
         this, read_options, rep_->internal_comparator,
+        range_del_agg, file_meta,
         NewIndexIterator(read_options),
         !skip_filters && !read_options.total_order_seek &&
             rep_->ioptions.prefix_extractor != nullptr);
@@ -1985,6 +2146,7 @@ InternalIterator* BlockBasedTable::NewIterator(const ReadOptions& read_options,
     auto* mem = arena->AllocateAligned(sizeof(BlockBasedTableIterator));
     return new (mem) BlockBasedTableIterator(
         this, read_options, rep_->internal_comparator,
+        range_del_agg, file_meta,
         NewIndexIterator(read_options),
         !skip_filters && !read_options.total_order_seek &&
             rep_->ioptions.prefix_extractor != nullptr);

--- a/table/cuckoo_table_reader.cc
+++ b/table/cuckoo_table_reader.cc
@@ -377,7 +377,11 @@ extern InternalIterator* NewErrorInternalIterator(const Status& status,
                                                   Arena* arena);
 
 InternalIterator* CuckooTableReader::NewIterator(
-    const ReadOptions& /*read_options*/, Arena* arena, bool /*skip_filters*/) {
+    const ReadOptions& /* read_options */,
+    RangeDelAggregator* /* range_del_agg */,
+    const FileMetaData* /* file_meta */,
+    Arena* arena,
+    bool /* skip_filters */) {
   if (!status().ok()) {
     return NewErrorInternalIterator(
         Status::Corruption("CuckooTableReader status is not okay."), arena);

--- a/table/cuckoo_table_reader.h
+++ b/table/cuckoo_table_reader.h
@@ -45,9 +45,11 @@ class CuckooTableReader: public TableReader {
   Status Get(const ReadOptions& read_options, const Slice& key,
              GetContext* get_context, bool skip_filters = false) override;
 
-  InternalIterator* NewIterator(
-      const ReadOptions&, Arena* arena = nullptr,
-      bool skip_filters = false) override;
+  InternalIterator* NewIterator(const ReadOptions&,
+                                RangeDelAggregator* range_del_agg = nullptr,
+                                const FileMetaData* file_meta = nullptr,
+                                Arena* arena = nullptr,
+                                bool skip_filters = false) override;
   void Prepare(const Slice& target) override;
 
   // Report an approximation of how much memory has been used.

--- a/table/cuckoo_table_reader_test.cc
+++ b/table/cuckoo_table_reader_test.cc
@@ -149,7 +149,8 @@ class CuckooReaderTest : public testing::Test {
     CuckooTableReader reader(ioptions, std::move(file_reader), file_size, ucomp,
                              GetSliceHash);
     ASSERT_OK(reader.status());
-    InternalIterator* it = reader.NewIterator(ReadOptions(), nullptr);
+    InternalIterator* it =
+        reader.NewIterator(ReadOptions(), nullptr, nullptr, nullptr);
     ASSERT_OK(it->status());
     ASSERT_TRUE(!it->Valid());
     it->SeekToFirst();
@@ -188,7 +189,7 @@ class CuckooReaderTest : public testing::Test {
     delete it;
 
     Arena arena;
-    it = reader.NewIterator(ReadOptions(), &arena);
+    it = reader.NewIterator(ReadOptions(), nullptr, nullptr, &arena);
     ASSERT_OK(it->status());
     ASSERT_TRUE(!it->Valid());
     it->Seek(keys[num_items/2]);

--- a/table/mock_table.cc
+++ b/table/mock_table.cc
@@ -26,9 +26,11 @@ stl_wrappers::KVMap MakeMockFile(
   return stl_wrappers::KVMap(l, stl_wrappers::LessOfComparator(&icmp_));
 }
 
-InternalIterator* MockTableReader::NewIterator(const ReadOptions&,
-                                               Arena* /*arena*/,
-                                               bool /*skip_filters*/) {
+InternalIterator* MockTableReader::NewIterator(
+    const ReadOptions&,
+    RangeDelAggregator* /* range_del_agg */,
+    const FileMetaData* /* file_meta */,
+    Arena* /*arena*/, bool /*skip_filters*/) {
   return new MockTableIterator(table_);
 }
 

--- a/table/mock_table.h
+++ b/table/mock_table.h
@@ -39,7 +39,9 @@ class MockTableReader : public TableReader {
   explicit MockTableReader(const stl_wrappers::KVMap& table) : table_(table) {}
 
   InternalIterator* NewIterator(const ReadOptions&,
-                                Arena* arena,
+                                RangeDelAggregator* range_del_agg = nullptr,
+                                const FileMetaData* file_meta = nullptr,
+                                Arena* arena = nullptr,
                                 bool skip_filters = false) override;
 
   Status Get(const ReadOptions&, const Slice& key, GetContext* get_context,

--- a/table/plain_table_reader.cc
+++ b/table/plain_table_reader.cc
@@ -189,9 +189,11 @@ Status PlainTableReader::Open(const ImmutableCFOptions& ioptions,
 void PlainTableReader::SetupForCompaction() {
 }
 
-InternalIterator* PlainTableReader::NewIterator(const ReadOptions& options,
-                                                Arena* arena,
-                                                bool /*skip_filters*/) {
+InternalIterator* PlainTableReader::NewIterator(
+    const ReadOptions& options,
+    RangeDelAggregator* /* range_del_agg */,
+    const FileMetaData* /* file_meta */,
+    Arena* arena, bool /*skip_filters*/) {
   bool use_prefix_seek = !IsTotalOrderMode() && !options.total_order_seek;
   if (arena == nullptr) {
     return new PlainTableIterator(this, use_prefix_seek);

--- a/table/plain_table_reader.h
+++ b/table/plain_table_reader.h
@@ -79,6 +79,8 @@ class PlainTableReader: public TableReader {
                      bool full_scan_mode);
 
   InternalIterator* NewIterator(const ReadOptions&,
+                                RangeDelAggregator* range_del_agg = nullptr,
+                                const FileMetaData* file_meta = nullptr,
                                 Arena* arena = nullptr,
                                 bool skip_filters = false) override;
 

--- a/table/table_reader.h
+++ b/table/table_reader.h
@@ -21,6 +21,8 @@ struct ReadOptions;
 struct TableProperties;
 class GetContext;
 class InternalIterator;
+struct FileMetaData;
+class RangeDelAggregator;
 
 // A Table is a sorted map from strings to strings.  Tables are
 // immutable and persistent.  A Table may be safely accessed from
@@ -39,6 +41,8 @@ class TableReader {
   // skip_filters: disables checking the bloom filters even if they exist. This
   //               option is effective only for block-based table format.
   virtual InternalIterator* NewIterator(const ReadOptions&,
+                                        RangeDelAggregator* range_del_agg = nullptr,
+                                        const FileMetaData* file_meta = nullptr,
                                         Arena* arena = nullptr,
                                         bool skip_filters = false) = 0;
 


### PR DESCRIPTION
[This is a backport to crl-release-5.13 of an upstream PR. I'll do my best to keep the implementations in sync as comments come in on both PRs.]

* Add RangeDelAggregator::GetTombstone
* Skip L0 sstables which are covered by a range tombstone
* Skip sstables that are entirely covered by a range tombstone

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/rocksdb/2)
<!-- Reviewable:end -->
