### PR TITLE
Backport the various range tombstone PRs

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,4 +1,11 @@
 # Rocksdb Change Log
+## 5.13.crl (7/13/2018)
+### Public API Change
+* The "rocksdb.num.entries" table property no longer counts range deletion tombstones as entries.
+
+### New Features
+* Add a new table property, "rocksdb.num.range-deletions", which counts the number of range deletion tombstones in the table.
+
 ## 5.13.4 (6/12/2018)
 ### Bug Fixes
 * Fix regression bug of Prev() with ReadOptions.iterate_upper_bound.

--- a/db/builder.cc
+++ b/db/builder.cc
@@ -157,7 +157,8 @@ Status BuildTable(
                                 nullptr /* upper_bound */, meta);
 
     // Finish and check for builder errors
-    bool empty = builder->NumEntries() == 0;
+    tp = builder->GetTableProperties();
+    bool empty = builder->NumEntries() == 0 && tp.num_range_deletions == 0;
     s = c_iter.status();
     if (!s.ok() || empty) {
       builder->Abandon();
@@ -170,7 +171,7 @@ Status BuildTable(
       meta->fd.file_size = file_size;
       meta->marked_for_compaction = builder->NeedCompact();
       assert(meta->fd.GetFileSize() > 0);
-      tp = builder->GetTableProperties();
+      tp = builder->GetTableProperties(); // refresh now that builder is finished
       if (table_properties) {
         *table_properties = tp;
       }

--- a/db/builder.cc
+++ b/db/builder.cc
@@ -100,7 +100,7 @@ Status BuildTable(
 #endif  // !ROCKSDB_LITE
   TableProperties tp;
 
-  if (iter->Valid() || range_del_agg->ShouldAddTombstones()) {
+  if (iter->Valid() || !range_del_agg->IsEmpty()) {
     TableBuilder* builder;
     unique_ptr<WritableFileWriter> file_writer;
     {
@@ -152,9 +152,14 @@ Status BuildTable(
             ThreadStatus::FLUSH_BYTES_WRITTEN, IOSTATS(bytes_written));
       }
     }
-    // nullptr for table_{min,max} so all range tombstones will be flushed
-    range_del_agg->AddToBuilder(builder, nullptr /* lower_bound */,
-                                nullptr /* upper_bound */, meta);
+
+    for (auto it = range_del_agg->NewIterator(); it->Valid(); it->Next()) {
+      auto tombstone = it->Tombstone();
+      auto kv = tombstone.Serialize();
+      builder->Add(kv.first.Encode(), kv.second);
+      meta->UpdateBoundariesForRange(kv.first, tombstone.SerializeEndKey(),
+                                     tombstone.seq_, internal_comparator);
+    }
 
     // Finish and check for builder errors
     tp = builder->GetTableProperties();

--- a/db/builder.cc
+++ b/db/builder.cc
@@ -200,7 +200,7 @@ Status BuildTable(
       // we will regrad this verification as user reads since the goal is
       // to cache it here for further user reads
       std::unique_ptr<InternalIterator> it(table_cache->NewIterator(
-          ReadOptions(), env_options, internal_comparator, meta->fd,
+          ReadOptions(), env_options, internal_comparator, *meta,
           nullptr /* range_del_agg */, nullptr,
           (internal_stats == nullptr) ? nullptr
                                       : internal_stats->GetFileReadHist(0),

--- a/db/compaction_iterator.cc
+++ b/db/compaction_iterator.cc
@@ -551,7 +551,7 @@ void CompactionIterator::NextFromInput() {
       // 1. new user key -OR-
       // 2. different snapshot stripe
       bool should_delete = range_del_agg_->ShouldDelete(
-          key_, RangeDelAggregator::RangePositioningMode::kForwardTraversal);
+          key_, RangeDelPositioningMode::kForwardTraversal);
       if (should_delete) {
         ++iter_stats_.num_record_drop_hidden;
         ++iter_stats_.num_record_drop_range_del;

--- a/db/compaction_job.cc
+++ b/db/compaction_job.cc
@@ -959,8 +959,7 @@ void CompactionJob::ProcessKeyValueCompaction(SubcompactionState* sub_compact) {
   }
 
   if (status.ok() && sub_compact->builder == nullptr &&
-      sub_compact->outputs.size() == 0 &&
-      range_del_agg->ShouldAddTombstones(bottommost_level_)) {
+      sub_compact->outputs.size() == 0) {
     // handle subcompaction containing only range deletions
     status = OpenCompactionOutputFile(sub_compact);
   }
@@ -1048,6 +1047,9 @@ Status CompactionJob::FinishCompactionOutputFile(
   uint64_t output_number = sub_compact->current_output()->meta.fd.GetNumber();
   assert(output_number != 0);
 
+  ColumnFamilyData* cfd = sub_compact->compaction->column_family_data();
+  const Comparator* ucmp = cfd->user_comparator();
+
   // Check for iterator errors
   Status s = input_status;
   auto meta = &sub_compact->current_output()->meta;
@@ -1079,9 +1081,71 @@ Status CompactionJob::FinishCompactionOutputFile(
       // subcompaction ends.
       upper_bound = sub_compact->end;
     }
-    range_del_agg->AddToBuilder(sub_compact->builder.get(), lower_bound,
-                                upper_bound, meta, range_del_out_stats,
-                                bottommost_level_);
+    auto earliest_snapshot = kMaxSequenceNumber;
+    if (existing_snapshots_.size() > 0) {
+      earliest_snapshot = existing_snapshots_[0];
+    }
+    auto it = range_del_agg->NewIterator();
+    if (lower_bound != nullptr) {
+      it->Seek(*lower_bound);
+    }
+    for (; it->Valid(); it->Next()) {
+      auto tombstone = it->Tombstone();
+      if (upper_bound != nullptr &&
+          ucmp->Compare(*upper_bound, tombstone.start_key_) <= 0) {
+        // Tombstones starting at upper_bound or later only need to be included
+        // in the next table. Break because subsequent tombstones will start
+        // even later.
+        break;
+      }
+
+      if (bottommost_level_ && tombstone.seq_ <= earliest_snapshot) {
+        // TODO(andrewkr): tombstones that span multiple output files are
+        // counted for each compaction output file, so lots of double counting.
+        range_del_out_stats->num_range_del_drop_obsolete++;
+        range_del_out_stats->num_record_drop_obsolete++;
+        continue;
+      }
+
+      auto kv = tombstone.Serialize();
+      sub_compact->builder->Add(kv.first.Encode(), kv.second);
+      InternalKey smallest_candidate = std::move(kv.first);
+      if (lower_bound != nullptr &&
+          ucmp->Compare(smallest_candidate.user_key(), *lower_bound) <= 0) {
+        // Pretend the smallest key has the same user key as lower_bound
+        // (the max key in the previous table or subcompaction) in order for
+        // files to appear key-space partitioned.
+        //
+        // Choose lowest seqnum so this file's smallest internal key comes
+        // after the previous file's/subcompaction's largest. The fake seqnum
+        // is OK because the read path's file-picking code only considers user
+        // key.
+        smallest_candidate = InternalKey(*lower_bound, 0, kTypeRangeDeletion);
+      }
+      InternalKey largest_candidate = tombstone.SerializeEndKey();
+      if (upper_bound != nullptr &&
+          ucmp->Compare(*upper_bound, largest_candidate.user_key()) <= 0) {
+        // Pretend the largest key has the same user key as upper_bound (the
+        // min key in the following table or subcompaction) in order for files
+        // to appear key-space partitioned.
+        //
+        // Choose highest seqnum so this file's largest internal key comes
+        // before the next file's/subcompaction's smallest. The fake seqnum is
+        // OK because the read path's file-picking code only considers the user
+        // key portion.
+        //
+        // Note Seek() also creates InternalKey with (user_key,
+        // kMaxSequenceNumber), but with kTypeDeletion (0x7) instead of
+        // kTypeRangeDeletion (0xF), so the range tombstone comes before the
+        // Seek() key in InternalKey's ordering. So Seek() will look in the
+        // next file for the user key.
+        largest_candidate =
+            InternalKey(*upper_bound, kMaxSequenceNumber, kTypeRangeDeletion);
+      }
+      meta->UpdateBoundariesForRange(smallest_candidate, largest_candidate,
+                                     tombstone.seq_,
+                                     cfd->internal_comparator());
+    }
     meta->marked_for_compaction = sub_compact->builder->NeedCompact();
   }
   const uint64_t current_entries = sub_compact->builder->NumEntries();
@@ -1129,7 +1193,6 @@ Status CompactionJob::FinishCompactionOutputFile(
     return s;
   }
 
-  ColumnFamilyData* cfd = sub_compact->compaction->column_family_data();
   if (s.ok() && (current_entries > 0 || tp.num_range_deletions > 0)) {
     // Verify that the table is usable
     // We set for_compaction to false and don't OptimizeForCompactionTableRead

--- a/db/compaction_job.cc
+++ b/db/compaction_job.cc
@@ -1201,7 +1201,7 @@ Status CompactionJob::FinishCompactionOutputFile(
     // we will regrad this verification as user reads since the goal is
     // to cache it here for further user reads
     InternalIterator* iter = cfd->table_cache()->NewIterator(
-        ReadOptions(), env_options_, cfd->internal_comparator(), meta->fd,
+        ReadOptions(), env_options_, cfd->internal_comparator(), *meta,
         nullptr /* range_del_agg */, nullptr,
         cfd->internal_stats()->GetFileReadHist(
             compact_->compaction->output_level()),

--- a/db/db_properties_test.cc
+++ b/db/db_properties_test.cc
@@ -170,6 +170,7 @@ void ResetTableProperties(TableProperties* tp) {
   tp->raw_value_size = 0;
   tp->num_data_blocks = 0;
   tp->num_entries = 0;
+  tp->num_range_deletions = 0;
 }
 
 void ParseTablePropertiesString(std::string tp_string, TableProperties* tp) {
@@ -179,15 +180,17 @@ void ParseTablePropertiesString(std::string tp_string, TableProperties* tp) {
   ResetTableProperties(tp);
 
   sscanf(tp_string.c_str(),
-         "# data blocks %" SCNu64 " # entries %" SCNu64 " raw key size %" SCNu64
+         "# data blocks %" SCNu64 " # entries %" SCNu64
+         " # range deletions %" SCNu64
+         " raw key size %" SCNu64
          " raw average key size %lf "
          " raw value size %" SCNu64
          " raw average value size %lf "
          " data block size %" SCNu64 " index block size %" SCNu64
          " filter block size %" SCNu64,
-         &tp->num_data_blocks, &tp->num_entries, &tp->raw_key_size,
-         &dummy_double, &tp->raw_value_size, &dummy_double, &tp->data_size,
-         &tp->index_size, &tp->filter_size);
+         &tp->num_data_blocks, &tp->num_entries, &tp->num_range_deletions,
+         &tp->raw_key_size, &dummy_double, &tp->raw_value_size, &dummy_double,
+         &tp->data_size, &tp->index_size, &tp->filter_size);
 }
 
 void VerifySimilar(uint64_t a, uint64_t b, double bias) {
@@ -218,19 +221,24 @@ void VerifyTableProperties(const TableProperties& base_tp,
   ASSERT_EQ(base_tp.raw_key_size, new_tp.raw_key_size);
   ASSERT_EQ(base_tp.raw_value_size, new_tp.raw_value_size);
   ASSERT_EQ(base_tp.num_entries, new_tp.num_entries);
+  ASSERT_EQ(base_tp.num_range_deletions, new_tp.num_range_deletions);
 }
 
 void GetExpectedTableProperties(TableProperties* expected_tp,
                                 const int kKeySize, const int kValueSize,
-                                const int kKeysPerTable, const int kTableCount,
+                                const int kKeysPerTable,
+                                const int kRangeDeletionsPerTable,
+                                const int kTableCount,
                                 const int kBloomBitsPerKey,
                                 const size_t kBlockSize) {
   const int kKeyCount = kTableCount * kKeysPerTable;
+  const int kRangeDeletionCount = kTableCount * kRangeDeletionsPerTable;
   const int kAvgSuccessorSize = kKeySize / 5;
   const int kEncodingSavePerKey = kKeySize / 4;
-  expected_tp->raw_key_size = kKeyCount * (kKeySize + 8);
-  expected_tp->raw_value_size = kKeyCount * kValueSize;
+  expected_tp->raw_key_size = (kKeyCount + kRangeDeletionCount) * (kKeySize + 8);
+  expected_tp->raw_value_size = (kKeyCount + kRangeDeletionCount) * kValueSize;
   expected_tp->num_entries = kKeyCount;
+  expected_tp->num_range_deletions = kRangeDeletionCount;
   expected_tp->num_data_blocks =
       kTableCount *
       (kKeysPerTable * (kKeySize - kEncodingSavePerKey + kValueSize)) /
@@ -287,6 +295,7 @@ TEST_F(DBPropertiesTest, ValidateSampleNumber) {
 
 TEST_F(DBPropertiesTest, AggregatedTableProperties) {
   for (int kTableCount = 40; kTableCount <= 100; kTableCount += 30) {
+    const int kRangeDeletionsPerTable = 5;
     const int kKeysPerTable = 100;
     const int kKeySize = 80;
     const int kValueSize = 200;
@@ -305,11 +314,21 @@ TEST_F(DBPropertiesTest, AggregatedTableProperties) {
 
     DestroyAndReopen(options);
 
+    // Hold open a snapshot to prevent range tombstones from being compacted
+    // away.
+    ManagedSnapshot snapshot(db_);
+
     Random rnd(5632);
     for (int table = 1; table <= kTableCount; ++table) {
       for (int i = 0; i < kKeysPerTable; ++i) {
         db_->Put(WriteOptions(), RandomString(&rnd, kKeySize),
                  RandomString(&rnd, kValueSize));
+      }
+      for (int i = 0; i < kRangeDeletionsPerTable; i++) {
+        std::string start = RandomString(&rnd, kKeySize);
+        std::string end = start;
+        end.resize(kValueSize);
+        db_->DeleteRange(WriteOptions(), db_->DefaultColumnFamily(), start, end);
       }
       db_->Flush(FlushOptions());
     }
@@ -318,7 +337,8 @@ TEST_F(DBPropertiesTest, AggregatedTableProperties) {
 
     TableProperties expected_tp;
     GetExpectedTableProperties(&expected_tp, kKeySize, kValueSize,
-                               kKeysPerTable, kTableCount, kBloomBitsPerKey,
+                               kKeysPerTable, kRangeDeletionsPerTable,
+                               kTableCount, kBloomBitsPerKey,
                                table_options.block_size);
 
     TableProperties output_tp;
@@ -437,6 +457,7 @@ TEST_F(DBPropertiesTest, ReadLatencyHistogramByLevel) {
 
 TEST_F(DBPropertiesTest, AggregatedTablePropertiesAtLevel) {
   const int kTableCount = 100;
+  const int kRangeDeletionsPerTable = 2;
   const int kKeysPerTable = 10;
   const int kKeySize = 50;
   const int kValueSize = 400;
@@ -462,6 +483,9 @@ TEST_F(DBPropertiesTest, AggregatedTablePropertiesAtLevel) {
 
   DestroyAndReopen(options);
 
+  // Hold open a snapshot to prevent range tombstones from being compacted away.
+  ManagedSnapshot snapshot(db_);
+
   std::string level_tp_strings[kMaxLevel];
   std::string tp_string;
   TableProperties level_tps[kMaxLevel];
@@ -470,6 +494,12 @@ TEST_F(DBPropertiesTest, AggregatedTablePropertiesAtLevel) {
     for (int i = 0; i < kKeysPerTable; ++i) {
       db_->Put(WriteOptions(), RandomString(&rnd, kKeySize),
                RandomString(&rnd, kValueSize));
+    }
+    for (int i = 0; i < kRangeDeletionsPerTable; i++) {
+      std::string start = RandomString(&rnd, kKeySize);
+      std::string end = start;
+      end.resize(kValueSize);
+      db_->DeleteRange(WriteOptions(), db_->DefaultColumnFamily(), start, end);
     }
     db_->Flush(FlushOptions());
     db_->CompactRange(CompactRangeOptions(), nullptr, nullptr);
@@ -486,6 +516,7 @@ TEST_F(DBPropertiesTest, AggregatedTablePropertiesAtLevel) {
       sum_tp.raw_value_size += level_tps[level].raw_value_size;
       sum_tp.num_data_blocks += level_tps[level].num_data_blocks;
       sum_tp.num_entries += level_tps[level].num_entries;
+      sum_tp.num_range_deletions += level_tps[level].num_range_deletions;
     }
     db_->GetProperty(DB::Properties::kAggregatedTableProperties, &tp_string);
     ParseTablePropertiesString(tp_string, &tp);
@@ -496,13 +527,15 @@ TEST_F(DBPropertiesTest, AggregatedTablePropertiesAtLevel) {
     ASSERT_EQ(sum_tp.raw_value_size, tp.raw_value_size);
     ASSERT_EQ(sum_tp.num_data_blocks, tp.num_data_blocks);
     ASSERT_EQ(sum_tp.num_entries, tp.num_entries);
+    ASSERT_EQ(sum_tp.num_range_deletions, tp.num_range_deletions);
     if (table > 3) {
-      GetExpectedTableProperties(&expected_tp, kKeySize, kValueSize,
-                                 kKeysPerTable, table, kBloomBitsPerKey,
-                                 table_options.block_size);
+      GetExpectedTableProperties(
+          &expected_tp, kKeySize, kValueSize, kKeysPerTable,
+          kRangeDeletionsPerTable, table, kBloomBitsPerKey,
+          table_options.block_size);
       // Gives larger bias here as index block size, filter block size,
       // and data block size become much harder to estimate in this test.
-      VerifyTableProperties(tp, expected_tp, 0.5, 0.4, 0.4, 0.25);
+      VerifyTableProperties(expected_tp, tp, 0.5, 0.4, 0.4, 0.25);
     }
   }
 }

--- a/db/db_range_del_test.cc
+++ b/db/db_range_del_test.cc
@@ -508,12 +508,12 @@ TEST_F(DBRangeDelTest, ObsoleteTombstoneCleanup) {
   Reopen(opts);
 
   db_->DeleteRange(WriteOptions(), db_->DefaultColumnFamily(), "dr1",
-                   "dr1");  // obsolete after compaction
+                   "dr10");  // obsolete after compaction
   db_->Put(WriteOptions(), "key", "val");
   db_->Flush(FlushOptions());
   const Snapshot* snapshot = db_->GetSnapshot();
   db_->DeleteRange(WriteOptions(), db_->DefaultColumnFamily(), "dr2",
-                   "dr2");  // protected by snapshot
+                   "dr20");  // protected by snapshot
   db_->Put(WriteOptions(), "key", "val");
   db_->Flush(FlushOptions());
 

--- a/db/db_range_del_test.cc
+++ b/db/db_range_del_test.cc
@@ -935,11 +935,14 @@ TEST_F(DBRangeDelTest, MemtableBloomFilter) {
 }
 
 TEST_F(DBRangeDelTest, CompactionTreatsSplitInputLevelDeletionAtomically) {
-  // make sure compaction treats files containing a split range deletion in the
-  // input level as an atomic unit. I.e., compacting any input-level file(s)
-  // containing a portion of the range deletion causes all other input-level
-  // files containing portions of that same range deletion to be included in the
-  // compaction.
+  // This test originally verified that compaction treated files containing a
+  // split range deletion in the input level as an atomic unit. I.e.,
+  // compacting any input-level file(s) containing a portion of the range
+  // deletion causes all other input-level files containing portions of that
+  // same range deletion to be included in the compaction. Range deletion
+  // tombstones are now truncated to sstable boundaries which removed the need
+  // for that behavior (which could lead to excessively large
+  // compactions).
   const int kNumFilesPerLevel = 4, kValueBytes = 4 << 10;
   Options options = CurrentOptions();
   options.compression = kNoCompression;
@@ -986,20 +989,109 @@ TEST_F(DBRangeDelTest, CompactionTreatsSplitInputLevelDeletionAtomically) {
     if (i == 0) {
       ASSERT_OK(db_->CompactFiles(
           CompactionOptions(), {meta.levels[1].files[0].name}, 2 /* level */));
+      ASSERT_EQ(0, NumTableFilesAtLevel(1));
     } else if (i == 1) {
       auto begin_str = Key(0), end_str = Key(1);
       Slice begin = begin_str, end = end_str;
       ASSERT_OK(db_->CompactRange(CompactRangeOptions(), &begin, &end));
+      ASSERT_EQ(3, NumTableFilesAtLevel(1));
     } else if (i == 2) {
       ASSERT_OK(db_->SetOptions(db_->DefaultColumnFamily(),
                                 {{"max_bytes_for_level_base", "10000"}}));
       dbfull()->TEST_WaitForCompact();
+      ASSERT_EQ(1, NumTableFilesAtLevel(1));
     }
-    ASSERT_EQ(0, NumTableFilesAtLevel(1));
     ASSERT_GT(NumTableFilesAtLevel(2), 0);
 
     db_->ReleaseSnapshot(snapshot);
   }
+}
+
+TEST_F(DBRangeDelTest, RangeTombstoneEndKeyAsSstableUpperBound) {
+  // Test the handling of the range-tombstone end-key as the
+  // upper-bound for an sstable.
+
+  const int kNumFilesPerLevel = 2, kValueBytes = 4 << 10;
+  Options options = CurrentOptions();
+  options.compression = kNoCompression;
+  options.level0_file_num_compaction_trigger = kNumFilesPerLevel;
+  options.memtable_factory.reset(
+      new SpecialSkipListFactory(2 /* num_entries_flush */));
+  options.target_file_size_base = kValueBytes;
+  options.disable_auto_compactions = true;
+
+  DestroyAndReopen(options);
+
+  // Create an initial sstable at L2:
+  //   [key000000#1,1, key000000#1,1]
+  ASSERT_OK(Put(Key(0), ""));
+  ASSERT_OK(db_->Flush(FlushOptions()));
+  MoveFilesToLevel(2);
+  ASSERT_EQ(1, NumTableFilesAtLevel(2));
+
+  // A snapshot protects the range tombstone from dropping due to
+  // becoming obsolete.
+  const Snapshot* snapshot = db_->GetSnapshot();
+  db_->DeleteRange(WriteOptions(), db_->DefaultColumnFamily(),
+                   Key(0), Key(2 * kNumFilesPerLevel));
+
+  // Create 2 additional sstables in L0. Note that the first sstable
+  // contains the range tombstone.
+  //   [key000000#3,1, key000004#72057594037927935,15]
+  //   [key000001#5,1, key000002#6,1]
+  Random rnd(301);
+  std::string value = RandomString(&rnd, kValueBytes);
+  for (int j = 0; j < kNumFilesPerLevel; ++j) {
+    // Give files overlapping key-ranges to prevent a trivial move when we
+    // compact from L0 to L1.
+    ASSERT_OK(Put(Key(j), value));
+    ASSERT_OK(Put(Key(2 * kNumFilesPerLevel - 1 - j), value));
+    ASSERT_OK(db_->Flush(FlushOptions()));
+    ASSERT_EQ(j + 1, NumTableFilesAtLevel(0));
+  }
+  // Compact the 2 L0 sstables to L1, resulting in the following LSM. There
+  // are 2 sstables generated in L1 due to the target_file_size_base setting.
+  //   L1:
+  //     [key000000#3,1, key000002#72057594037927935,15]
+  //     [key000002#6,1, key000004#72057594037927935,15]
+  //   L2:
+  //     [key000000#1,1, key000000#1,1]
+  MoveFilesToLevel(1);
+  ASSERT_EQ(2, NumTableFilesAtLevel(1));
+
+  {
+    // Compact the second sstable in L1:
+    //   L1:
+    //     [key000000#3,1, key000002#72057594037927935,15]
+    //   L2:
+    //     [key000000#1,1, key000000#1,1]
+    //     [key000002#6,1, key000004#72057594037927935,15]
+    auto begin_str = Key(3);
+    const rocksdb::Slice begin = begin_str;
+    dbfull()->TEST_CompactRange(1, &begin, nullptr);
+    ASSERT_EQ(1, NumTableFilesAtLevel(1));
+    ASSERT_EQ(2, NumTableFilesAtLevel(2));
+  }
+
+  {
+    // Compact the first sstable in L1. This should be copacetic, but
+    // was previously resulting in overlapping sstables in L2 due to
+    // mishandling of the range tombstone end-key when used as the
+    // largest key for an sstable. The resulting LSM structure should
+    // be:
+    //
+    //   L2:
+    //     [key000000#1,1, key000001#72057594037927935,15]
+    //     [key000001#5,1, key000002#72057594037927935,15]
+    //     [key000002#6,1, key000004#72057594037927935,15]
+    auto begin_str = Key(0);
+    const rocksdb::Slice begin = begin_str;
+    dbfull()->TEST_CompactRange(1, &begin, &begin);
+    ASSERT_EQ(0, NumTableFilesAtLevel(1));
+    ASSERT_EQ(3, NumTableFilesAtLevel(2));
+  }
+
+  db_->ReleaseSnapshot(snapshot);
 }
 
 TEST_F(DBRangeDelTest, UnorderedTombstones) {

--- a/db/db_range_del_test.cc
+++ b/db/db_range_del_test.cc
@@ -813,6 +813,25 @@ TEST_F(DBRangeDelTest, IteratorIgnoresRangeDeletions) {
   db_->ReleaseSnapshot(snapshot);
 }
 
+TEST_F(DBRangeDelTest, IteratorCoveredSst) {
+  // TODO(peter): generate multiple sstables with some being covered
+  // by tombstones and some that aren't.
+  db_->Put(WriteOptions(), "key", "val");
+  ASSERT_OK(db_->Flush(FlushOptions()));
+  db_->CompactRange(CompactRangeOptions(), nullptr, nullptr);
+  ASSERT_OK(db_->DeleteRange(WriteOptions(), db_->DefaultColumnFamily(), "a", "z"));
+
+  ReadOptions read_opts;
+  auto* iter = db_->NewIterator(read_opts);
+
+  int count = 0;
+  for (iter->SeekToFirst(); iter->Valid(); iter->Next()) {
+    ++count;
+  }
+  ASSERT_EQ(0, count);
+  delete iter;
+}
+
 #ifndef ROCKSDB_UBSAN_RUN
 TEST_F(DBRangeDelTest, TailingIteratorRangeTombstoneUnsupported) {
   db_->Put(WriteOptions(), "key", "val");

--- a/db/dbformat.h
+++ b/db/dbformat.h
@@ -135,10 +135,14 @@ inline Slice ExtractUserKey(const Slice& internal_key) {
   return Slice(internal_key.data(), internal_key.size() - 8);
 }
 
-inline ValueType ExtractValueType(const Slice& internal_key) {
+inline uint64_t ExtractInternalKeyFooter(const Slice& internal_key) {
   assert(internal_key.size() >= 8);
   const size_t n = internal_key.size();
-  uint64_t num = DecodeFixed64(internal_key.data() + n - 8);
+  return DecodeFixed64(internal_key.data() + n - 8);
+}
+
+inline ValueType ExtractValueType(const Slice& internal_key) {
+  uint64_t num = ExtractInternalKeyFooter(internal_key);
   unsigned char c = num & 0xff;
   return static_cast<ValueType>(c);
 }
@@ -601,9 +605,15 @@ struct RangeTombstone {
     return InternalKey(start_key_, seq_, kTypeRangeDeletion);
   }
 
+  // The tombstone end-key is exclusive, so we generate an internal-key here
+  // which has a similar property. Using kMaxSequenceNumber guarantees that
+  // the returned internal-key will compare less than any other internal-key
+  // with the same user-key. This in turn guarantees that the serialized
+  // end-key for a tombstone such as [a-b] will compare less than the key "b".
+  //
   // be careful to use SerializeEndKey(), allocates new memory
   InternalKey SerializeEndKey() const {
-    return InternalKey(end_key_, seq_, kTypeRangeDeletion);
+    return InternalKey(end_key_, kMaxSequenceNumber, kTypeRangeDeletion);
   }
 };
 

--- a/db/dbformat_test.cc
+++ b/db/dbformat_test.cc
@@ -192,6 +192,13 @@ TEST_F(FormatTest, UpdateInternalKey) {
   ASSERT_EQ(new_val_type, decoded.type);
 }
 
+TEST_F(FormatTest, RangeTombstoneSerializeEndKey) {
+  RangeTombstone t("a", "b", 2);
+  InternalKey k("b", 3, kTypeValue);
+  const InternalKeyComparator cmp(BytewiseComparator());
+  ASSERT_LT(cmp.Compare(t.SerializeEndKey(), k), 0);
+}
+
 }  // namespace rocksdb
 
 int main(int argc, char** argv) {

--- a/db/forward_iterator.cc
+++ b/db/forward_iterator.cc
@@ -73,7 +73,7 @@ class ForwardLevelIterator : public InternalIterator {
         cfd_->internal_comparator(), {} /* snapshots */);
     file_iter_ = cfd_->table_cache()->NewIterator(
         read_options_, *(cfd_->soptions()), cfd_->internal_comparator(),
-        files_[file_index_]->fd,
+        *files_[file_index_],
         read_options_.ignore_range_deletions ? nullptr : &range_del_agg,
         nullptr /* table_reader_ptr */, nullptr, false);
     file_iter_->SetPinnedItersMgr(pinned_iters_mgr_);
@@ -610,7 +610,7 @@ void ForwardIterator::RebuildIterators(bool refresh_sv) {
       continue;
     }
     l0_iters_.push_back(cfd_->table_cache()->NewIterator(
-        read_options_, *cfd_->soptions(), cfd_->internal_comparator(), l0->fd,
+        read_options_, *cfd_->soptions(), cfd_->internal_comparator(), *l0,
         read_options_.ignore_range_deletions ? nullptr : &range_del_agg));
   }
   BuildLevelIterators(vstorage);
@@ -680,7 +680,7 @@ void ForwardIterator::RenewIterators() {
     }
     l0_iters_new.push_back(cfd_->table_cache()->NewIterator(
         read_options_, *cfd_->soptions(), cfd_->internal_comparator(),
-        l0_files_new[inew]->fd,
+        *l0_files_new[inew],
         read_options_.ignore_range_deletions ? nullptr : &range_del_agg));
   }
 
@@ -738,7 +738,7 @@ void ForwardIterator::ResetIncompleteIterators() {
     DeleteIterator(l0_iters_[i]);
     l0_iters_[i] = cfd_->table_cache()->NewIterator(
         read_options_, *cfd_->soptions(), cfd_->internal_comparator(),
-        l0_files[i]->fd, nullptr /* range_del_agg */);
+        *l0_files[i], nullptr /* range_del_agg */);
     l0_iters_[i]->SetPinnedItersMgr(pinned_iters_mgr_);
   }
 

--- a/db/merge_helper.cc
+++ b/db/merge_helper.cc
@@ -236,8 +236,7 @@ Status MergeHelper::MergeUntil(InternalIterator* iter,
       if (filter != CompactionFilter::Decision::kRemoveAndSkipUntil &&
           range_del_agg != nullptr &&
           range_del_agg->ShouldDelete(
-              iter->key(),
-              RangeDelAggregator::RangePositioningMode::kForwardTraversal)) {
+              iter->key(), RangeDelPositioningMode::kForwardTraversal)) {
         filter = CompactionFilter::Decision::kRemove;
       }
       if (filter == CompactionFilter::Decision::kKeep ||

--- a/db/range_del_aggregator.cc
+++ b/db/range_del_aggregator.cc
@@ -536,4 +536,11 @@ bool RangeDelAggregator::IsEmpty() {
   return true;
 }
 
+bool RangeDelAggregator::AddFile(uint64_t file_number) {
+  if (rep_ == nullptr) {
+    return true;
+  }
+  return rep_->added_files_.emplace(file_number).second;
+}
+
 }  // namespace rocksdb

--- a/db/range_del_aggregator.cc
+++ b/db/range_del_aggregator.cc
@@ -4,10 +4,351 @@
 //  (found in the LICENSE.Apache file in the root directory).
 
 #include "db/range_del_aggregator.h"
+#include "util/heap.h"
 
 #include <algorithm>
 
 namespace rocksdb {
+
+struct TombstoneStartKeyComparator {
+  TombstoneStartKeyComparator(const Comparator* c) : cmp(c) {}
+
+  bool operator()(const RangeTombstone& a, const RangeTombstone& b) const {
+    return cmp->Compare(a.start_key_, b.start_key_) < 0;
+  }
+
+  const Comparator* cmp;
+};
+
+// An UncollapsedRangeDelMap is quick to create but slow to answer ShouldDelete
+// queries.
+class UncollapsedRangeDelMap : public RangeDelMap {
+  typedef std::multiset<RangeTombstone, TombstoneStartKeyComparator> Rep;
+
+  class Iterator : public RangeDelIterator {
+    const Rep& rep_;
+    Rep::const_iterator iter_;
+
+   public:
+    Iterator(const Rep& rep) : rep_(rep), iter_(rep.begin()) {}
+    bool Valid() const override { return iter_ != rep_.end(); }
+    void Next() override { iter_++; }
+
+    void Seek(const Slice&) override {
+      fprintf(stderr, "UncollapsedRangeDelMap::Iterator::Seek unimplemented\n");
+      abort();
+    }
+
+    RangeTombstone Tombstone() const override { return *iter_; }
+  };
+
+  Rep rep_;
+  const Comparator* ucmp_;
+
+ public:
+  UncollapsedRangeDelMap(const Comparator* ucmp)
+      : rep_(TombstoneStartKeyComparator(ucmp)), ucmp_(ucmp) {}
+
+  bool ShouldDelete(const ParsedInternalKey& parsed,
+                    RangeDelPositioningMode mode) {
+    (void)mode;
+    assert(mode == RangeDelPositioningMode::kFullScan);
+    for (const auto& tombstone : rep_) {
+      if (ucmp_->Compare(parsed.user_key, tombstone.start_key_) < 0) {
+        break;
+      }
+      if (parsed.sequence < tombstone.seq_ &&
+          ucmp_->Compare(parsed.user_key, tombstone.end_key_) < 0) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  bool IsRangeOverlapped(const Slice& start, const Slice& end) {
+    for (const auto& tombstone : rep_) {
+      if (ucmp_->Compare(start, tombstone.end_key_) < 0 &&
+          ucmp_->Compare(tombstone.start_key_, end) <= 0 &&
+          ucmp_->Compare(tombstone.start_key_, tombstone.end_key_) < 0) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  void AddTombstone(RangeTombstone tombstone) { rep_.emplace(tombstone); }
+
+  size_t Size() const { return rep_.size(); }
+
+  void InvalidatePosition() {}  // no-op
+
+  std::unique_ptr<RangeDelIterator> NewIterator() {
+    return std::unique_ptr<RangeDelIterator>(new Iterator(this->rep_));
+  }
+};
+
+// A CollapsedRangeDelMap is slow to create but quick to answer ShouldDelete
+// queries.
+//
+// An explanation of the design follows. Suppose we have tombstones [b, n) @ 1,
+// [e, h) @ 2, [q, t) @ 2, and [g, k) @ 3. Visually, the tombstones look like
+// this:
+//
+//     3:        g---k
+//     2:     e---h        q--t
+//     1:  b------------n
+//
+// The CollapsedRangeDelMap representation is based on the observation that
+// wherever tombstones overlap, we need only store the tombstone with the
+// largest seqno. From the perspective of a read at seqno 4 or greater, this set
+// of tombstones is exactly equivalent:
+//
+//     3:        g---k
+//     2:     e--g         q--t
+//     1:  b--e      k--n
+//
+// Because these tombstones do not overlap, they can be efficiently represented
+// in an ordered map from keys to sequence numbers. Each entry should be thought
+// of as a transition from one tombstone to the next. In this example, the
+// CollapsedRangeDelMap would store the following entries, in order:
+//
+//     b → 1, e → 2, g → 3, k → 1, n → 0, q → 2, t → 0
+//
+// If a tombstone ends before the next tombstone begins, a sentinel seqno of 0
+// is installed to indicate that no tombstone exists. This occurs at keys n and
+// t in the example above.
+//
+// To check whether a key K is covered by a tombstone, the map is binary
+// searched for the last key less than K. K is covered iff the map entry has a
+// larger seqno than K. As an example, consider the key h @ 4. It would be
+// compared against the map entry g → 3 and determined to be uncovered. By
+// contrast, the key h @ 2 would be determined to be covered.
+class CollapsedRangeDelMap : public RangeDelMap {
+  typedef std::map<Slice, SequenceNumber, stl_wrappers::LessOfComparator> Rep;
+
+  class Iterator : public RangeDelIterator {
+    void MaybeSeekPastSentinel() {
+      if (Valid() && iter_->second == 0) {
+        iter_++;
+      }
+    }
+
+    const Rep& rep_;
+    Rep::const_iterator iter_;
+
+   public:
+    Iterator(const Rep& rep) : rep_(rep), iter_(rep.begin()) {}
+
+    bool Valid() const override { return iter_ != rep_.end(); }
+
+    void Next() override {
+      iter_++;
+      MaybeSeekPastSentinel();
+    }
+
+    void Seek(const Slice& target) override {
+      iter_ = rep_.upper_bound(target);
+      if (iter_ != rep_.begin()) {
+        iter_--;
+      }
+      MaybeSeekPastSentinel();
+    }
+
+    RangeTombstone Tombstone() const override {
+      RangeTombstone tombstone;
+      tombstone.start_key_ = iter_->first;
+      tombstone.end_key_ = std::next(iter_)->first;
+      tombstone.seq_ = iter_->second;
+      return tombstone;
+    }
+  };
+
+  Rep rep_;
+  Rep::iterator iter_;
+  const Comparator* ucmp_;
+
+ public:
+  CollapsedRangeDelMap(const Comparator* ucmp) : ucmp_(ucmp) {
+    InvalidatePosition();
+  }
+
+  bool ShouldDelete(const ParsedInternalKey& parsed,
+                    RangeDelPositioningMode mode) {
+    if (iter_ == rep_.end() &&
+        (mode == RangeDelPositioningMode::kForwardTraversal ||
+         mode == RangeDelPositioningMode::kBackwardTraversal)) {
+      // invalid (e.g., if AddTombstones() changed the deletions), so need to
+      // reseek
+      mode = RangeDelPositioningMode::kBinarySearch;
+    }
+    switch (mode) {
+      case RangeDelPositioningMode::kFullScan:
+        assert(false);
+      case RangeDelPositioningMode::kForwardTraversal:
+        assert(iter_ != rep_.end());
+        if (iter_ == rep_.begin() &&
+            ucmp_->Compare(parsed.user_key, iter_->first) < 0) {
+          // before start of deletion intervals
+          return false;
+        }
+        while (std::next(iter_) != rep_.end() &&
+               ucmp_->Compare(std::next(iter_)->first, parsed.user_key) <= 0) {
+          ++iter_;
+        }
+        break;
+      case RangeDelPositioningMode::kBackwardTraversal:
+        assert(iter_ != rep_.end());
+        while (iter_ != rep_.begin() &&
+               ucmp_->Compare(parsed.user_key, iter_->first) < 0) {
+          --iter_;
+        }
+        if (iter_ == rep_.begin() &&
+            ucmp_->Compare(parsed.user_key, iter_->first) < 0) {
+          // before start of deletion intervals
+          return false;
+        }
+        break;
+      case RangeDelPositioningMode::kBinarySearch:
+        iter_ = rep_.upper_bound(parsed.user_key);
+        if (iter_ == rep_.begin()) {
+          // before start of deletion intervals
+          return false;
+        }
+        --iter_;
+        break;
+    }
+    assert(iter_ != rep_.end() &&
+           ucmp_->Compare(iter_->first, parsed.user_key) <= 0);
+    assert(std::next(iter_) == rep_.end() ||
+           ucmp_->Compare(parsed.user_key, std::next(iter_)->first) < 0);
+    return parsed.sequence < iter_->second;
+  }
+
+  bool IsRangeOverlapped(const Slice&, const Slice&) {
+    // Unimplemented because the only client of this method, file ingestion,
+    // uses uncollapsed maps.
+    fprintf(stderr, "CollapsedRangeDelMap::IsRangeOverlapped unimplemented");
+    abort();
+  }
+
+  void AddTombstone(RangeTombstone t) {
+    if (ucmp_->Compare(t.start_key_, t.end_key_) >= 0) {
+      // The tombstone covers no keys. Nothing to do.
+      return;
+    }
+
+    auto it = rep_.upper_bound(t.start_key_);
+    auto prev_seq = [&]() {
+      return it == rep_.begin() ? 0 : std::prev(it)->second;
+    };
+
+    // end_seq stores the seqno of the last transition that the new tombstone
+    // covered. This is the seqno that we'll install if we need to insert a
+    // transition for the new tombstone's end key.
+    SequenceNumber end_seq = 0;
+
+    // In the diagrams below, the new tombstone is always [c, k) @ 2. The
+    // existing tombstones are varied to depict different scenarios. Uppercase
+    // letters are used to indicate points that exist in the map, while
+    // lowercase letters are used to indicate points that do not exist in the
+    // map. The location of the iterator is marked with a caret; it may point
+    // off the end of the diagram to indicate that it is positioned at a
+    // entry with a larger key whose specific key is irrelevant.
+
+    if (t.seq_ > prev_seq()) {
+      // The new tombstone's start point covers the existing tombstone:
+      //
+      //     3:                3: A--C           3:                3:
+      //     2:    c---   OR   2:    c---   OR   2:    c---   OR   2: c------
+      //     1: A--C           1:                1: A------        1: C------
+      //                ^                 ^                 ^                  ^
+      // Insert a new transition at the new tombstone's start point, or raise
+      // the existing transition at that point to the new tombstone's seqno.
+      end_seq = prev_seq();
+      rep_[t.start_key_] = t.seq_;  // operator[] will overwrite existing entry
+    } else {
+      // The new tombstone's start point is covered by an existing tombstone:
+      //
+      //      3: A-----   OR    3: C------
+      //      2:   c---         2: c------
+      //                ^                  ^
+      // Do nothing.
+    }
+
+    // Look at all the existing transitions that overlap the new tombstone.
+    while (it != rep_.end() && ucmp_->Compare(it->first, t.end_key_) < 0) {
+      if (t.seq_ > it->second) {
+        // The transition is to an existing tombstone that the new tombstone
+        // covers. Save the covered tombstone's seqno. We'll need to return to
+        // it if the new tombstone ends before the existing tombstone.
+        end_seq = it->second;
+
+        if (t.seq_ == prev_seq()) {
+          // The previous transition is to the seqno of the new tombstone:
+          //
+          //     3:                3:                3: --F
+          //     2: C------   OR   2: C------   OR   2:   F----
+          //     1:    F---        1: ---F           1:     H--
+          //           ^                 ^                  ^
+          //
+          // Erase this transition. It's been superseded.
+          it = rep_.erase(it);
+          continue;  // skip increment; erase positions iterator correctly
+        } else {
+          // The previous transition is to a tombstone that covers the new
+          // tombstone, but this transition is to a tombstone that is covered by
+          // the new tombstone. That is, this is the end of a run of existing
+          // tombstones that cover the new tombstone:
+          //
+          //     3: A---E     OR   3:  E-G
+          //     2:   c----        2: ------
+          //            ^                ^
+          // Preserve this transition point, but raise it to the new tombstone's
+          // seqno.
+          it->second = t.seq_;
+        }
+      } else {
+        // The transition is to an existing tombstone that covers the new
+        // tombstone:
+        //
+        //     4:              4: --F
+        //     3:   F--   OR   3:   F--
+        //     2: -----        2: -----
+        //          ^               ^
+        // Do nothing.
+      }
+      ++it;
+    }
+
+    if (t.seq_ == prev_seq()) {
+      // The new tombstone is unterminated in the map:
+      //
+      //     3:             OR   3: --G       OR   3: --G   K--
+      //     2: C-------k        2:   G---k        2:   G---k
+      //                  ^                 ^               ^
+      // End it now, returning to the last seqno we covered. Because end keys
+      // are exclusive, if there's an existing transition at t.end_key_, it
+      // takes precedence over the transition that we install here.
+      rep_.emplace(t.end_key_, end_seq);  // emplace is a noop if existing entry
+    } else {
+      // The new tombstone is implicitly ended because its end point is covered
+      // by an existing tombstone with a higher seqno.
+      //
+      //     3:   I---M   OR   3: A-----------M
+      //     2: ----k          2:   c-------k
+      //              ^                       ^
+      // Do nothing.
+    }
+  }
+
+  size_t Size() const { return rep_.size() - 1; }
+
+  void InvalidatePosition() { iter_ = rep_.end(); }
+
+  std::unique_ptr<RangeDelIterator> NewIterator() {
+    return std::unique_ptr<RangeDelIterator>(new Iterator(this->rep_));
+  }
+};
 
 RangeDelAggregator::RangeDelAggregator(
     const InternalKeyComparator& icmp,
@@ -30,21 +371,25 @@ void RangeDelAggregator::InitRep(const std::vector<SequenceNumber>& snapshots) {
   assert(rep_ == nullptr);
   rep_.reset(new Rep());
   for (auto snapshot : snapshots) {
-    rep_->stripe_map_.emplace(
-        snapshot,
-        PositionalTombstoneMap(TombstoneMap(
-            stl_wrappers::LessOfComparator(icmp_.user_comparator()))));
+    rep_->stripe_map_.emplace(snapshot, NewRangeDelMap());
   }
   // Data newer than any snapshot falls in this catch-all stripe
-  rep_->stripe_map_.emplace(
-      kMaxSequenceNumber,
-      PositionalTombstoneMap(TombstoneMap(
-          stl_wrappers::LessOfComparator(icmp_.user_comparator()))));
+  rep_->stripe_map_.emplace(kMaxSequenceNumber, NewRangeDelMap());
   rep_->pinned_iters_mgr_.StartPinning();
 }
 
-bool RangeDelAggregator::ShouldDeleteImpl(
-    const Slice& internal_key, RangeDelAggregator::RangePositioningMode mode) {
+std::unique_ptr<RangeDelMap> RangeDelAggregator::NewRangeDelMap() {
+  RangeDelMap* tombstone_map;
+  if (collapse_deletions_) {
+    tombstone_map = new CollapsedRangeDelMap(icmp_.user_comparator());
+  } else {
+    tombstone_map = new UncollapsedRangeDelMap(icmp_.user_comparator());
+  }
+  return std::unique_ptr<RangeDelMap>(tombstone_map);
+}
+
+bool RangeDelAggregator::ShouldDeleteImpl(const Slice& internal_key,
+                                          RangeDelPositioningMode mode) {
   assert(rep_ != nullptr);
   ParsedInternalKey parsed;
   if (!ParseInternalKey(internal_key, &parsed)) {
@@ -53,136 +398,29 @@ bool RangeDelAggregator::ShouldDeleteImpl(
   return ShouldDelete(parsed, mode);
 }
 
-bool RangeDelAggregator::ShouldDeleteImpl(
-    const ParsedInternalKey& parsed,
-    RangeDelAggregator::RangePositioningMode mode) {
+bool RangeDelAggregator::ShouldDeleteImpl(const ParsedInternalKey& parsed,
+                                          RangeDelPositioningMode mode) {
   assert(IsValueType(parsed.type));
   assert(rep_ != nullptr);
-  auto& positional_tombstone_map = GetPositionalTombstoneMap(parsed.sequence);
-  const auto& tombstone_map = positional_tombstone_map.raw_map;
-  if (tombstone_map.empty()) {
+  auto& tombstone_map = GetRangeDelMap(parsed.sequence);
+  if (tombstone_map.IsEmpty()) {
     return false;
   }
-  auto& tombstone_map_iter = positional_tombstone_map.iter;
-  if (tombstone_map_iter == tombstone_map.end() &&
-      (mode == kForwardTraversal || mode == kBackwardTraversal)) {
-    // invalid (e.g., if AddTombstones() changed the deletions), so need to
-    // reseek
-    mode = kBinarySearch;
-  }
-  switch (mode) {
-    case kFullScan:
-      assert(!collapse_deletions_);
-      // The maintained state (PositionalTombstoneMap::iter) isn't useful when
-      // we linear scan from the beginning each time, but we maintain it anyways
-      // for consistency.
-      tombstone_map_iter = tombstone_map.begin();
-      while (tombstone_map_iter != tombstone_map.end()) {
-        const auto& tombstone = tombstone_map_iter->second;
-        if (icmp_.user_comparator()->Compare(parsed.user_key,
-                                             tombstone.start_key_) < 0) {
-          break;
-        }
-        if (parsed.sequence < tombstone.seq_ &&
-            icmp_.user_comparator()->Compare(parsed.user_key,
-                                             tombstone.end_key_) < 0) {
-          return true;
-        }
-        ++tombstone_map_iter;
-      }
-      return false;
-    case kForwardTraversal:
-      assert(collapse_deletions_ && tombstone_map_iter != tombstone_map.end());
-      if (tombstone_map_iter == tombstone_map.begin() &&
-          icmp_.user_comparator()->Compare(parsed.user_key,
-                                           tombstone_map_iter->first) < 0) {
-        // before start of deletion intervals
-        return false;
-      }
-      while (std::next(tombstone_map_iter) != tombstone_map.end() &&
-             icmp_.user_comparator()->Compare(
-                 std::next(tombstone_map_iter)->first, parsed.user_key) <= 0) {
-        ++tombstone_map_iter;
-      }
-      break;
-    case kBackwardTraversal:
-      assert(collapse_deletions_ && tombstone_map_iter != tombstone_map.end());
-      while (tombstone_map_iter != tombstone_map.begin() &&
-             icmp_.user_comparator()->Compare(parsed.user_key,
-                                              tombstone_map_iter->first) < 0) {
-        --tombstone_map_iter;
-      }
-      if (tombstone_map_iter == tombstone_map.begin() &&
-          icmp_.user_comparator()->Compare(parsed.user_key,
-                                           tombstone_map_iter->first) < 0) {
-        // before start of deletion intervals
-        return false;
-      }
-      break;
-    case kBinarySearch:
-      assert(collapse_deletions_);
-      tombstone_map_iter =
-          tombstone_map.upper_bound(parsed.user_key);
-      if (tombstone_map_iter == tombstone_map.begin()) {
-        // before start of deletion intervals
-        return false;
-      }
-      --tombstone_map_iter;
-      break;
-  }
-  assert(mode != kFullScan);
-  assert(tombstone_map_iter != tombstone_map.end() &&
-         icmp_.user_comparator()->Compare(tombstone_map_iter->first,
-                                          parsed.user_key) <= 0);
-  assert(std::next(tombstone_map_iter) == tombstone_map.end() ||
-         icmp_.user_comparator()->Compare(
-             parsed.user_key, std::next(tombstone_map_iter)->first) < 0);
-  return parsed.sequence < tombstone_map_iter->second.seq_;
+  return tombstone_map.ShouldDelete(parsed, mode);
 }
 
 bool RangeDelAggregator::IsRangeOverlapped(const Slice& start,
                                            const Slice& end) {
-  // so far only implemented for non-collapsed mode since file ingestion (only
-  //  client) doesn't use collapsing
+  // Unimplemented because the only client of this method, file ingestion,
+  // uses uncollapsed maps.
   assert(!collapse_deletions_);
   if (rep_ == nullptr) {
     return false;
   }
-  for (const auto& seqnum_and_tombstone_map : rep_->stripe_map_) {
-    for (const auto& start_key_and_tombstone :
-         seqnum_and_tombstone_map.second.raw_map) {
-      const auto& tombstone = start_key_and_tombstone.second;
-      if (icmp_.user_comparator()->Compare(start, tombstone.end_key_) < 0 &&
-          icmp_.user_comparator()->Compare(tombstone.start_key_, end) <= 0 &&
-          icmp_.user_comparator()->Compare(tombstone.start_key_,
-                                           tombstone.end_key_) < 0) {
-        return true;
-      }
-    }
-  }
-  return false;
-}
-
-bool RangeDelAggregator::ShouldAddTombstones(
-    bool bottommost_level /* = false */) {
-  // TODO(andrewkr): can we just open a file and throw it away if it ends up
-  // empty after AddToBuilder()? This function doesn't take into subcompaction
-  // boundaries so isn't completely accurate.
-  if (rep_ == nullptr) {
-    return false;
-  }
-  auto stripe_map_iter = rep_->stripe_map_.begin();
-  assert(stripe_map_iter != rep_->stripe_map_.end());
-  if (bottommost_level) {
-    // For the bottommost level, keys covered by tombstones in the first
-    // (oldest) stripe have been compacted away, so the tombstones are obsolete.
-    ++stripe_map_iter;
-  }
-  while (stripe_map_iter != rep_->stripe_map_.end()) {
-    if (!stripe_map_iter->second.raw_map.empty()) {
+  for (const auto& stripe : rep_->stripe_map_) {
+    if (stripe.second->IsRangeOverlapped(start, end)) {
       return true;
     }
-    ++stripe_map_iter;
   }
   return false;
 }
@@ -199,7 +437,7 @@ Status RangeDelAggregator::AddTombstones(
       if (rep_ == nullptr) {
         InitRep({upper_bound_});
       } else {
-        InvalidateTombstoneMapPositions();
+        InvalidateRangeDelMapPositions();
       }
       first_iter = false;
     }
@@ -208,7 +446,7 @@ Status RangeDelAggregator::AddTombstones(
       return Status::Corruption("Unable to parse range tombstone InternalKey");
     }
     RangeTombstone tombstone(parsed_key, input->value());
-    AddTombstone(std::move(tombstone));
+    GetRangeDelMap(tombstone.seq_).AddTombstone(std::move(tombstone));
     input->Next();
   }
   if (!first_iter) {
@@ -217,173 +455,16 @@ Status RangeDelAggregator::AddTombstones(
   return Status::OK();
 }
 
-void RangeDelAggregator::InvalidateTombstoneMapPositions() {
+void RangeDelAggregator::InvalidateRangeDelMapPositions() {
   if (rep_ == nullptr) {
     return;
   }
-  for (auto stripe_map_iter = rep_->stripe_map_.begin();
-       stripe_map_iter != rep_->stripe_map_.end(); ++stripe_map_iter) {
-    stripe_map_iter->second.iter = stripe_map_iter->second.raw_map.end();
+  for (auto& stripe : rep_->stripe_map_) {
+    stripe.second->InvalidatePosition();
   }
 }
 
-Status RangeDelAggregator::AddTombstone(RangeTombstone tombstone) {
-  auto& positional_tombstone_map = GetPositionalTombstoneMap(tombstone.seq_);
-  auto& tombstone_map = positional_tombstone_map.raw_map;
-  if (collapse_deletions_) {
-    // In collapsed mode, we only fill the seq_ field in the TombstoneMap's
-    // values. The end_key is unneeded because we assume the tombstone extends
-    // until the next tombstone starts. For gaps between real tombstones and
-    // for the last real tombstone, we denote end keys by inserting fake
-    // tombstones with sequence number zero.
-    std::vector<RangeTombstone> new_range_dels{
-        tombstone, RangeTombstone(tombstone.end_key_, Slice(), 0)};
-    auto new_range_dels_iter = new_range_dels.begin();
-    // Position at the first overlapping existing tombstone; if none exists,
-    // insert until we find an existing one overlapping a new point
-    const Slice* tombstone_map_begin = nullptr;
-    if (!tombstone_map.empty()) {
-      tombstone_map_begin = &tombstone_map.begin()->first;
-    }
-    auto last_range_dels_iter = new_range_dels_iter;
-    while (new_range_dels_iter != new_range_dels.end() &&
-           (tombstone_map_begin == nullptr ||
-            icmp_.user_comparator()->Compare(new_range_dels_iter->start_key_,
-                                             *tombstone_map_begin) < 0)) {
-      tombstone_map.emplace(
-          new_range_dels_iter->start_key_,
-          RangeTombstone(Slice(), Slice(), new_range_dels_iter->seq_));
-      last_range_dels_iter = new_range_dels_iter;
-      ++new_range_dels_iter;
-    }
-    if (new_range_dels_iter == new_range_dels.end()) {
-      return Status::OK();
-    }
-    // above loop advances one too far
-    new_range_dels_iter = last_range_dels_iter;
-    auto tombstone_map_iter =
-        tombstone_map.upper_bound(new_range_dels_iter->start_key_);
-    // if nothing overlapped we would've already inserted all the new points
-    // and returned early
-    assert(tombstone_map_iter != tombstone_map.begin());
-    tombstone_map_iter--;
-
-    // untermed_seq is non-kMaxSequenceNumber when we covered an existing point
-    // but haven't seen its corresponding endpoint. It's used for (1) deciding
-    // whether to forcibly insert the new interval's endpoint; and (2) possibly
-    // raising the seqnum for the to-be-inserted element (we insert the max
-    // seqnum between the next new interval and the unterminated interval).
-    SequenceNumber untermed_seq = kMaxSequenceNumber;
-    while (tombstone_map_iter != tombstone_map.end() &&
-           new_range_dels_iter != new_range_dels.end()) {
-      const Slice *tombstone_map_iter_end = nullptr,
-                  *new_range_dels_iter_end = nullptr;
-      if (tombstone_map_iter != tombstone_map.end()) {
-        auto next_tombstone_map_iter = std::next(tombstone_map_iter);
-        if (next_tombstone_map_iter != tombstone_map.end()) {
-          tombstone_map_iter_end = &next_tombstone_map_iter->first;
-        }
-      }
-      if (new_range_dels_iter != new_range_dels.end()) {
-        auto next_new_range_dels_iter = std::next(new_range_dels_iter);
-        if (next_new_range_dels_iter != new_range_dels.end()) {
-          new_range_dels_iter_end = &next_new_range_dels_iter->start_key_;
-        }
-      }
-
-      // our positions in existing/new tombstone collections should always
-      // overlap. The non-overlapping cases are handled above and below this
-      // loop.
-      assert(new_range_dels_iter_end == nullptr ||
-             icmp_.user_comparator()->Compare(tombstone_map_iter->first,
-                                              *new_range_dels_iter_end) < 0);
-      assert(tombstone_map_iter_end == nullptr ||
-             icmp_.user_comparator()->Compare(new_range_dels_iter->start_key_,
-                                              *tombstone_map_iter_end) < 0);
-
-      int new_to_old_start_cmp = icmp_.user_comparator()->Compare(
-          new_range_dels_iter->start_key_, tombstone_map_iter->first);
-      // nullptr end means extends infinitely rightwards, set new_to_old_end_cmp
-      // accordingly so we can use common code paths later.
-      int new_to_old_end_cmp;
-      if (new_range_dels_iter_end == nullptr &&
-          tombstone_map_iter_end == nullptr) {
-        new_to_old_end_cmp = 0;
-      } else if (new_range_dels_iter_end == nullptr) {
-        new_to_old_end_cmp = 1;
-      } else if (tombstone_map_iter_end == nullptr) {
-        new_to_old_end_cmp = -1;
-      } else {
-        new_to_old_end_cmp = icmp_.user_comparator()->Compare(
-            *new_range_dels_iter_end, *tombstone_map_iter_end);
-      }
-
-      if (new_to_old_start_cmp < 0) {
-        // the existing one's left endpoint comes after, so raise/delete it if
-        // it's covered.
-        if (tombstone_map_iter->second.seq_ < new_range_dels_iter->seq_) {
-          untermed_seq = tombstone_map_iter->second.seq_;
-          if (tombstone_map_iter != tombstone_map.begin() &&
-              std::prev(tombstone_map_iter)->second.seq_ ==
-                  new_range_dels_iter->seq_) {
-            tombstone_map_iter = tombstone_map.erase(tombstone_map_iter);
-            --tombstone_map_iter;
-          } else {
-            tombstone_map_iter->second.seq_ = new_range_dels_iter->seq_;
-          }
-        }
-      } else if (new_to_old_start_cmp > 0) {
-        if (untermed_seq != kMaxSequenceNumber ||
-            tombstone_map_iter->second.seq_ < new_range_dels_iter->seq_) {
-          auto seq = tombstone_map_iter->second.seq_;
-          // need to adjust this element if not intended to span beyond the new
-          // element (i.e., was_tombstone_map_iter_raised == true), or if it
-          // can be raised
-          tombstone_map_iter = tombstone_map.emplace(
-              new_range_dels_iter->start_key_,
-              RangeTombstone(
-                  Slice(), Slice(),
-                  std::max(
-                      untermed_seq == kMaxSequenceNumber ? 0 : untermed_seq,
-                      new_range_dels_iter->seq_)));
-          untermed_seq = seq;
-        }
-      } else {
-        // their left endpoints coincide, so raise the existing one if needed
-        if (tombstone_map_iter->second.seq_ < new_range_dels_iter->seq_) {
-          untermed_seq = tombstone_map_iter->second.seq_;
-          tombstone_map_iter->second.seq_ = new_range_dels_iter->seq_;
-        }
-      }
-
-      // advance whichever one ends earlier, or both if their right endpoints
-      // coincide
-      if (new_to_old_end_cmp < 0) {
-        ++new_range_dels_iter;
-      } else if (new_to_old_end_cmp > 0) {
-        ++tombstone_map_iter;
-        untermed_seq = kMaxSequenceNumber;
-      } else {
-        ++new_range_dels_iter;
-        ++tombstone_map_iter;
-        untermed_seq = kMaxSequenceNumber;
-      }
-    }
-    while (new_range_dels_iter != new_range_dels.end()) {
-      tombstone_map.emplace(
-          new_range_dels_iter->start_key_,
-          RangeTombstone(Slice(), Slice(), new_range_dels_iter->seq_));
-      ++new_range_dels_iter;
-    }
-  } else {
-    auto start_key = tombstone.start_key_;
-    tombstone_map.emplace(start_key, std::move(tombstone));
-  }
-  return Status::OK();
-}
-
-RangeDelAggregator::PositionalTombstoneMap&
-RangeDelAggregator::GetPositionalTombstoneMap(SequenceNumber seq) {
+RangeDelMap& RangeDelAggregator::GetRangeDelMap(SequenceNumber seq) {
   assert(rep_ != nullptr);
   // The stripe includes seqnum for the snapshot above and excludes seqnum for
   // the snapshot below.
@@ -396,140 +477,15 @@ RangeDelAggregator::GetPositionalTombstoneMap(SequenceNumber seq) {
   }
   // catch-all stripe justifies this assertion in either of above cases
   assert(iter != rep_->stripe_map_.end());
-  return iter->second;
-}
-
-// TODO(andrewkr): We should implement an iterator over range tombstones in our
-// map. It'd enable compaction to open tables on-demand, i.e., only once range
-// tombstones are known to be available, without the code duplication we have
-// in ShouldAddTombstones(). It'll also allow us to move the table-modifying
-// code into more coherent places: CompactionJob and BuildTable().
-void RangeDelAggregator::AddToBuilder(
-    TableBuilder* builder, const Slice* lower_bound, const Slice* upper_bound,
-    FileMetaData* meta,
-    CompactionIterationStats* range_del_out_stats /* = nullptr */,
-    bool bottommost_level /* = false */) {
-  if (rep_ == nullptr) {
-    return;
-  }
-  auto stripe_map_iter = rep_->stripe_map_.begin();
-  assert(stripe_map_iter != rep_->stripe_map_.end());
-  if (bottommost_level) {
-    // TODO(andrewkr): these are counted for each compaction output file, so
-    // lots of double-counting.
-    if (!stripe_map_iter->second.raw_map.empty()) {
-      range_del_out_stats->num_range_del_drop_obsolete +=
-          static_cast<int64_t>(stripe_map_iter->second.raw_map.size()) -
-          (collapse_deletions_ ? 1 : 0);
-      range_del_out_stats->num_record_drop_obsolete +=
-          static_cast<int64_t>(stripe_map_iter->second.raw_map.size()) -
-          (collapse_deletions_ ? 1 : 0);
-    }
-    // For the bottommost level, keys covered by tombstones in the first
-    // (oldest) stripe have been compacted away, so the tombstones are obsolete.
-    ++stripe_map_iter;
-  }
-
-  // Note the order in which tombstones are stored is insignificant since we
-  // insert them into a std::map on the read path.
-  while (stripe_map_iter != rep_->stripe_map_.end()) {
-    bool first_added = false;
-    for (auto tombstone_map_iter = stripe_map_iter->second.raw_map.begin();
-         tombstone_map_iter != stripe_map_iter->second.raw_map.end();
-         ++tombstone_map_iter) {
-      RangeTombstone tombstone;
-      if (collapse_deletions_) {
-        auto next_tombstone_map_iter = std::next(tombstone_map_iter);
-        if (next_tombstone_map_iter == stripe_map_iter->second.raw_map.end() ||
-            tombstone_map_iter->second.seq_ == 0) {
-          // it's a sentinel tombstone
-          continue;
-        }
-        tombstone.start_key_ = tombstone_map_iter->first;
-        tombstone.end_key_ = next_tombstone_map_iter->first;
-        tombstone.seq_ = tombstone_map_iter->second.seq_;
-      } else {
-        tombstone = tombstone_map_iter->second;
-      }
-      if (upper_bound != nullptr &&
-          icmp_.user_comparator()->Compare(*upper_bound,
-                                           tombstone.start_key_) <= 0) {
-        // Tombstones starting at upper_bound or later only need to be included
-        // in the next table. Break because subsequent tombstones will start
-        // even later.
-        break;
-      }
-      if (lower_bound != nullptr &&
-          icmp_.user_comparator()->Compare(tombstone.end_key_,
-                                           *lower_bound) <= 0) {
-        // Tombstones ending before or at lower_bound only need to be included
-        // in the prev table. Continue because subsequent tombstones may still
-        // overlap [lower_bound, upper_bound).
-        continue;
-      }
-
-      auto ikey_and_end_key = tombstone.Serialize();
-      builder->Add(ikey_and_end_key.first.Encode(), ikey_and_end_key.second);
-      if (!first_added) {
-        first_added = true;
-        InternalKey smallest_candidate = std::move(ikey_and_end_key.first);
-        if (lower_bound != nullptr &&
-            icmp_.user_comparator()->Compare(smallest_candidate.user_key(),
-                                             *lower_bound) <= 0) {
-          // Pretend the smallest key has the same user key as lower_bound
-          // (the max key in the previous table or subcompaction) in order for
-          // files to appear key-space partitioned.
-          //
-          // Choose lowest seqnum so this file's smallest internal key comes
-          // after the previous file's/subcompaction's largest. The fake seqnum
-          // is OK because the read path's file-picking code only considers user
-          // key.
-          smallest_candidate = InternalKey(*lower_bound, 0, kTypeRangeDeletion);
-        }
-        if (meta->smallest.size() == 0 ||
-            icmp_.Compare(smallest_candidate, meta->smallest) < 0) {
-          meta->smallest = std::move(smallest_candidate);
-        }
-      }
-      InternalKey largest_candidate = tombstone.SerializeEndKey();
-      if (upper_bound != nullptr &&
-          icmp_.user_comparator()->Compare(*upper_bound,
-                                           largest_candidate.user_key()) <= 0) {
-        // Pretend the largest key has the same user key as upper_bound (the
-        // min key in the following table or subcompaction) in order for files
-        // to appear key-space partitioned.
-        //
-        // Choose highest seqnum so this file's largest internal key comes
-        // before the next file's/subcompaction's smallest. The fake seqnum is
-        // OK because the read path's file-picking code only considers the user
-        // key portion.
-        //
-        // Note Seek() also creates InternalKey with (user_key,
-        // kMaxSequenceNumber), but with kTypeDeletion (0x7) instead of
-        // kTypeRangeDeletion (0xF), so the range tombstone comes before the
-        // Seek() key in InternalKey's ordering. So Seek() will look in the
-        // next file for the user key.
-        largest_candidate = InternalKey(*upper_bound, kMaxSequenceNumber,
-                                        kTypeRangeDeletion);
-      }
-      if (meta->largest.size() == 0 ||
-          icmp_.Compare(meta->largest, largest_candidate) < 0) {
-        meta->largest = std::move(largest_candidate);
-      }
-      meta->smallest_seqno = std::min(meta->smallest_seqno, tombstone.seq_);
-      meta->largest_seqno = std::max(meta->largest_seqno, tombstone.seq_);
-    }
-    ++stripe_map_iter;
-  }
+  return *iter->second;
 }
 
 bool RangeDelAggregator::IsEmpty() {
   if (rep_ == nullptr) {
     return true;
   }
-  for (auto stripe_map_iter = rep_->stripe_map_.begin();
-       stripe_map_iter != rep_->stripe_map_.end(); ++stripe_map_iter) {
-    if (!stripe_map_iter->second.raw_map.empty()) {
+  for (const auto& stripe : rep_->stripe_map_) {
+    if (!stripe.second->IsEmpty()) {
       return false;
     }
   }
@@ -541,6 +497,77 @@ bool RangeDelAggregator::AddFile(uint64_t file_number) {
     return true;
   }
   return rep_->added_files_.emplace(file_number).second;
+}
+
+class MergingRangeDelIter : public RangeDelIterator {
+ public:
+  MergingRangeDelIter(const Comparator* c)
+      : heap_(IterMinHeap(IterComparator(c))), current_(nullptr) {}
+
+  void AddIterator(std::unique_ptr<RangeDelIterator> iter) {
+    if (iter->Valid()) {
+      heap_.push(iter.get());
+      iters_.push_back(std::move(iter));
+      current_ = heap_.top();
+    }
+  }
+
+  bool Valid() const override { return current_ != nullptr; }
+
+  void Next() override {
+    current_->Next();
+    if (current_->Valid()) {
+      heap_.replace_top(current_);
+    } else {
+      heap_.pop();
+    }
+    current_ = heap_.empty() ? nullptr : heap_.top();
+  }
+
+  void Seek(const Slice& target) override {
+    heap_.clear();
+    for (auto& iter : iters_) {
+      iter->Seek(target);
+      if (iter->Valid()) {
+        heap_.push(iter.get());
+      }
+    }
+    current_ = heap_.empty() ? nullptr : heap_.top();
+  }
+
+  RangeTombstone Tombstone() const override { return current_->Tombstone(); }
+
+ private:
+  struct IterComparator {
+    IterComparator(const Comparator* c) : cmp(c) {}
+
+    bool operator()(const RangeDelIterator* a,
+                    const RangeDelIterator* b) const {
+      // Note: counterintuitively, returning the tombstone with the larger start
+      // key puts the tombstone with the smallest key at the top of the heap.
+      return cmp->Compare(a->Tombstone().start_key_,
+                          b->Tombstone().start_key_) > 0;
+    }
+
+    const Comparator* cmp;
+  };
+
+  typedef BinaryHeap<RangeDelIterator*, IterComparator> IterMinHeap;
+
+  std::vector<std::unique_ptr<RangeDelIterator>> iters_;
+  IterMinHeap heap_;
+  RangeDelIterator* current_;
+};
+
+std::unique_ptr<RangeDelIterator> RangeDelAggregator::NewIterator() {
+  std::unique_ptr<MergingRangeDelIter> iter(
+      new MergingRangeDelIter(icmp_.user_comparator()));
+  if (rep_ != nullptr) {
+    for (const auto& stripe : rep_->stripe_map_) {
+      iter->AddIterator(stripe.second->NewIterator());
+    }
+  }
+  return std::move(iter);
 }
 
 }  // namespace rocksdb

--- a/db/range_del_aggregator.cc
+++ b/db/range_del_aggregator.cc
@@ -521,7 +521,9 @@ bool RangeDelAggregator::IsRangeOverlapped(const Slice& start,
 }
 
 Status RangeDelAggregator::AddTombstones(
-    std::unique_ptr<InternalIterator> input) {
+    std::unique_ptr<InternalIterator> input,
+    const InternalKey* smallest,
+    const InternalKey* largest) {
   if (input == nullptr) {
     return Status::OK();
   }
@@ -541,6 +543,29 @@ Status RangeDelAggregator::AddTombstones(
       return Status::Corruption("Unable to parse range tombstone InternalKey");
     }
     RangeTombstone tombstone(parsed_key, input->value());
+    // Truncate the tombstone to the range [smallest, largest].
+    if (smallest != nullptr) {
+      if (icmp_.user_comparator()->Compare(
+              tombstone.start_key_, smallest->user_key()) < 0) {
+        tombstone.start_key_ = smallest->user_key();
+      }
+    }
+    if (largest != nullptr) {
+      // This is subtly correct despite the discrepancy between
+      // FileMetaData::largest being inclusive while RangeTombstone::end_key_
+      // is exclusive. A tombstone will only extend past the bounds of an
+      // sstable if its end-key is the largest key in the table. If that
+      // occurs, the largest key for the table is set based on the smallest
+      // key in the next table in the level. In that case, largest->user_key()
+      // is not actually a key in the current table and thus we can use it as
+      // the exclusive end-key for the tombstone.
+      if (icmp_.user_comparator()->Compare(
+              tombstone.end_key_, largest->user_key()) > 0) {
+        // The largest key should be a tombstone sentinel key.
+        assert(GetInternalKeySeqno(largest->Encode()) == kMaxSequenceNumber);
+        tombstone.end_key_ = largest->user_key();
+      }
+    }
     GetRangeDelMap(tombstone.seq_).AddTombstone(std::move(tombstone));
     input->Next();
   }

--- a/db/range_del_aggregator.h
+++ b/db/range_del_aggregator.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include <map>
+#include <set>
 #include <string>
 #include <vector>
 
@@ -140,6 +141,7 @@ class RangeDelAggregator {
                     CompactionIterationStats* range_del_out_stats = nullptr,
                     bool bottommost_level = false);
   bool IsEmpty();
+  bool AddFile(uint64_t file_number);
 
  private:
   // Maps tombstone user start key -> tombstone object
@@ -166,6 +168,7 @@ class RangeDelAggregator {
   struct Rep {
     StripeMap stripe_map_;
     PinnedIteratorsManager pinned_iters_mgr_;
+    std::set<uint64_t> added_files_;
   };
   // Initializes rep_ lazily. This aggregator object is constructed for every
   // read, so expensive members should only be created when necessary, i.e.,

--- a/db/range_del_aggregator.h
+++ b/db/range_del_aggregator.h
@@ -61,6 +61,8 @@ class RangeDelMap {
 
   virtual bool ShouldDelete(const ParsedInternalKey& parsed,
                             RangeDelPositioningMode mode) = 0;
+  virtual bool ShouldDeleteRange(const Slice& start, const Slice& end,
+                                 SequenceNumber seqno) = 0;
   virtual bool IsRangeOverlapped(const Slice& start, const Slice& end) = 0;
   virtual void InvalidatePosition() = 0;
 
@@ -126,6 +128,13 @@ class RangeDelAggregator {
                         RangeDelPositioningMode mode);
   bool ShouldDeleteImpl(const Slice& internal_key,
                         RangeDelPositioningMode mode);
+
+  // Return true if one or more tombstones that are newer than seqno fully
+  // cover the range [start,end] (both endpoints are inclusive). Beware the
+  // inclusive endpoint which differs from most other key ranges, but matches
+  // the largest_key metadata for an sstable.
+  bool ShouldDeleteRange(const Slice& start, const Slice& end,
+                         SequenceNumber seqno);
 
   // Checks whether range deletions cover any keys between `start` and `end`,
   // inclusive.

--- a/db/range_del_aggregator.h
+++ b/db/range_del_aggregator.h
@@ -23,6 +23,54 @@
 
 namespace rocksdb {
 
+// RangeDelMaps maintain position across calls to ShouldDelete. The caller may
+// wish to specify a mode to optimize positioning the iterator during the next
+// call to ShouldDelete. The non-kFullScan modes are only available when
+// deletion collapsing is enabled.
+//
+// For example, if we invoke Next() on an iterator, kForwardTraversal should be
+// specified to advance one-by-one through deletions until one is found with its
+// interval containing the key. This will typically be faster than doing a full
+// binary search (kBinarySearch).
+enum class RangeDelPositioningMode {
+  kFullScan,  // used iff collapse_deletions_ == false
+  kForwardTraversal,
+  kBackwardTraversal,
+  kBinarySearch,
+};
+
+// A RangeDelIterator iterates over range deletion tombstones.
+class RangeDelIterator {
+ public:
+  virtual ~RangeDelIterator() = default;
+
+  virtual bool Valid() const = 0;
+  virtual void Next() = 0;
+  virtual void Seek(const Slice& target) = 0;
+  virtual RangeTombstone Tombstone() const = 0;
+};
+
+// A RangeDelMap keeps track of range deletion tombstones within a snapshot
+// stripe.
+//
+// RangeDelMaps are used internally by RangeDelAggregator. They are not intended
+// to be used directly.
+class RangeDelMap {
+ public:
+  virtual ~RangeDelMap() = default;
+
+  virtual bool ShouldDelete(const ParsedInternalKey& parsed,
+                            RangeDelPositioningMode mode) = 0;
+  virtual bool IsRangeOverlapped(const Slice& start, const Slice& end) = 0;
+  virtual void InvalidatePosition() = 0;
+
+  virtual size_t Size() const = 0;
+  bool IsEmpty() const { return Size() == 0; }
+
+  virtual void AddTombstone(RangeTombstone tombstone) = 0;
+  virtual std::unique_ptr<RangeDelIterator> NewIterator() = 0;
+};
+
 // A RangeDelAggregator aggregates range deletion tombstones as they are
 // encountered in memtables/SST files. It provides methods that check whether a
 // key is covered by range tombstones or write the relevant tombstones to a new
@@ -53,45 +101,31 @@ class RangeDelAggregator {
                      SequenceNumber upper_bound,
                      bool collapse_deletions = false);
 
-  // We maintain position in the tombstone map across calls to ShouldDelete. The
-  // caller may wish to specify a mode to optimize positioning the iterator
-  // during the next call to ShouldDelete. The non-kFullScan modes are only
-  // available when deletion collapsing is enabled.
-  //
-  // For example, if we invoke Next() on an iterator, kForwardTraversal should
-  // be specified to advance one-by-one through deletions until one is found
-  // with its interval containing the key. This will typically be faster than
-  // doing a full binary search (kBinarySearch).
-  enum RangePositioningMode {
-    kFullScan,  // used iff collapse_deletions_ == false
-    kForwardTraversal,
-    kBackwardTraversal,
-    kBinarySearch,
-  };
-
   // Returns whether the key should be deleted, which is the case when it is
   // covered by a range tombstone residing in the same snapshot stripe.
   // @param mode If collapse_deletions_ is true, this dictates how we will find
   //             the deletion whose interval contains this key. Otherwise, its
   //             value must be kFullScan indicating linear scan from beginning..
-  bool ShouldDelete(const ParsedInternalKey& parsed,
-                    RangePositioningMode mode = kFullScan) {
+  bool ShouldDelete(
+      const ParsedInternalKey& parsed,
+      RangeDelPositioningMode mode = RangeDelPositioningMode::kFullScan) {
     if (rep_ == nullptr) {
       return false;
     }
     return ShouldDeleteImpl(parsed, mode);
   }
-  bool ShouldDelete(const Slice& internal_key,
-                    RangePositioningMode mode = kFullScan) {
+  bool ShouldDelete(
+      const Slice& internal_key,
+      RangeDelPositioningMode mode = RangeDelPositioningMode::kFullScan) {
     if (rep_ == nullptr) {
       return false;
     }
     return ShouldDeleteImpl(internal_key, mode);
   }
   bool ShouldDeleteImpl(const ParsedInternalKey& parsed,
-                        RangePositioningMode mode = kFullScan);
+                        RangeDelPositioningMode mode);
   bool ShouldDeleteImpl(const Slice& internal_key,
-                        RangePositioningMode mode = kFullScan);
+                        RangeDelPositioningMode mode);
 
   // Checks whether range deletions cover any keys between `start` and `end`,
   // inclusive.
@@ -101,8 +135,6 @@ class RangeDelAggregator {
   //     argument is inclusive, so the existence of a range deletion covering
   //     `end` causes this to return true.
   bool IsRangeOverlapped(const Slice& start, const Slice& end);
-
-  bool ShouldAddTombstones(bool bottommost_level = false);
 
   // Adds tombstones to the tombstone aggregation structure maintained by this
   // object.
@@ -114,56 +146,23 @@ class RangeDelAggregator {
   // if it's an iterator that just seeked to an arbitrary position. The effect
   // of invalidation is that the following call to ShouldDelete() will binary
   // search for its tombstone.
-  void InvalidateTombstoneMapPositions();
+  void InvalidateRangeDelMapPositions();
 
-  // Writes tombstones covering a range to a table builder.
-  // @param extend_before_min_key If true, the range of tombstones to be added
-  //    to the TableBuilder starts from the beginning of the key-range;
-  //    otherwise, it starts from meta->smallest.
-  // @param lower_bound/upper_bound Any range deletion with [start_key, end_key)
-  //    that overlaps the target range [*lower_bound, *upper_bound) is added to
-  //    the builder. If lower_bound is nullptr, the target range extends
-  //    infinitely to the left. If upper_bound is nullptr, the target range
-  //    extends infinitely to the right. If both are nullptr, the target range
-  //    extends infinitely in both directions, i.e., all range deletions are
-  //    added to the builder.
-  // @param meta The file's metadata. We modify the begin and end keys according
-  //    to the range tombstones added to this file such that the read path does
-  //    not miss range tombstones that cover gaps before/after/between files in
-  //    a level. lower_bound/upper_bound above constrain how far file boundaries
-  //    can be extended.
-  // @param bottommost_level If true, we will filter out any tombstones
-  //    belonging to the oldest snapshot stripe, because all keys potentially
-  //    covered by this tombstone are guaranteed to have been deleted by
-  //    compaction.
-  void AddToBuilder(TableBuilder* builder, const Slice* lower_bound,
-                    const Slice* upper_bound, FileMetaData* meta,
-                    CompactionIterationStats* range_del_out_stats = nullptr,
-                    bool bottommost_level = false);
   bool IsEmpty();
   bool AddFile(uint64_t file_number);
 
+  // Create a new iterator over the range deletion tombstones in all of the
+  // snapshot stripes in this aggregator. Tombstones are presented in start key
+  // order. Tombstones with the same start key are presented in arbitrary order.
+  //
+  // The iterator is invalidated after any call to AddTombstones. It is the
+  // caller's responsibility to avoid using invalid iterators.
+  std::unique_ptr<RangeDelIterator> NewIterator();
+
  private:
-  // Maps tombstone user start key -> tombstone object
-  typedef std::multimap<Slice, RangeTombstone, stl_wrappers::LessOfComparator>
-      TombstoneMap;
-  // Also maintains position in TombstoneMap last seen by ShouldDelete(). The
-  // end iterator indicates invalidation (e.g., if AddTombstones() changes the
-  // underlying map). End iterator cannot be invalidated.
-  struct PositionalTombstoneMap {
-    explicit PositionalTombstoneMap(TombstoneMap _raw_map)
-        : raw_map(std::move(_raw_map)), iter(raw_map.end()) {}
-    PositionalTombstoneMap(const PositionalTombstoneMap&) = delete;
-    PositionalTombstoneMap(PositionalTombstoneMap&& other)
-        : raw_map(std::move(other.raw_map)), iter(raw_map.end()) {}
-
-    TombstoneMap raw_map;
-    TombstoneMap::const_iterator iter;
-  };
-
   // Maps snapshot seqnum -> map of tombstones that fall in that stripe, i.e.,
   // their seqnums are greater than the next smaller snapshot's seqnum.
-  typedef std::map<SequenceNumber, PositionalTombstoneMap> StripeMap;
+  typedef std::map<SequenceNumber, std::unique_ptr<RangeDelMap>> StripeMap;
 
   struct Rep {
     StripeMap stripe_map_;
@@ -175,8 +174,8 @@ class RangeDelAggregator {
   // once the first range deletion is encountered.
   void InitRep(const std::vector<SequenceNumber>& snapshots);
 
-  PositionalTombstoneMap& GetPositionalTombstoneMap(SequenceNumber seq);
-  Status AddTombstone(RangeTombstone tombstone);
+  std::unique_ptr<RangeDelMap> NewRangeDelMap();
+  RangeDelMap& GetRangeDelMap(SequenceNumber seq);
 
   SequenceNumber upper_bound_;
   std::unique_ptr<Rep> rep_;

--- a/db/range_del_aggregator.h
+++ b/db/range_del_aggregator.h
@@ -63,6 +63,8 @@ class RangeDelMap {
                             RangeDelPositioningMode mode) = 0;
   virtual bool ShouldDeleteRange(const Slice& start, const Slice& end,
                                  SequenceNumber seqno) = 0;
+  virtual RangeTombstone GetTombstone(const Slice& user_key,
+                                      SequenceNumber seqno) = 0;
   virtual bool IsRangeOverlapped(const Slice& start, const Slice& end) = 0;
   virtual void InvalidatePosition() = 0;
 
@@ -135,6 +137,13 @@ class RangeDelAggregator {
   // the largest_key metadata for an sstable.
   bool ShouldDeleteRange(const Slice& start, const Slice& end,
                          SequenceNumber seqno);
+
+  // Get the range tombstone at the specified user_key and sequence number. A
+  // valid tombstone is always returned, though it may cover an empty range of
+  // keys or the sequence number may be 0 to indicate that no tombstone covers
+  // the specified range of keys.
+  RangeTombstone GetTombstone(const Slice& user_key,
+                              SequenceNumber seqno);
 
   // Checks whether range deletions cover any keys between `start` and `end`,
   // inclusive.

--- a/db/range_del_aggregator.h
+++ b/db/range_del_aggregator.h
@@ -155,9 +155,15 @@ class RangeDelAggregator {
   bool IsRangeOverlapped(const Slice& start, const Slice& end);
 
   // Adds tombstones to the tombstone aggregation structure maintained by this
-  // object.
+  // object. Tombstones are truncated to smallest and largest. If smallest (or
+  // largest) is null, it is not used for truncation. When adding range
+  // tombstones present in an sstable, smallest and largest should be set to
+  // the smallest and largest keys from the sstable file metadata. Note that
+  // tombstones end keys are exclusive while largest is inclusive.
   // @return non-OK status if any of the tombstone keys are corrupted.
-  Status AddTombstones(std::unique_ptr<InternalIterator> input);
+  Status AddTombstones(std::unique_ptr<InternalIterator> input,
+                       const InternalKey* smallest = nullptr,
+                       const InternalKey* largest = nullptr);
 
   // Resets iterators maintained across calls to ShouldDelete(). This may be
   // called when the tombstones change, or the owner may call explicitly, e.g.,

--- a/db/range_del_aggregator_test.cc
+++ b/db/range_del_aggregator_test.cc
@@ -21,6 +21,12 @@ struct ExpectedPoint {
   SequenceNumber seq;
 };
 
+struct ExpectedRange {
+  Slice begin;
+  Slice end;
+  SequenceNumber seq;
+};
+
 enum Direction {
   kForward,
   kReverse,
@@ -119,6 +125,25 @@ void VerifyRangeDels(
       ASSERT_FALSE(overlapped);
     }
   }
+}
+
+bool ShouldDeleteRange(const std::vector<RangeTombstone>& range_dels,
+                       const ExpectedRange& expected_range) {
+  RangeDelAggregator range_del_agg(icmp, {} /* snapshots */, true);
+  std::vector<std::string> keys, values;
+  for (const auto& range_del : range_dels) {
+    auto key_and_value = range_del.Serialize();
+    keys.push_back(key_and_value.first.Encode().ToString());
+    values.push_back(key_and_value.second.ToString());
+  }
+  std::unique_ptr<test::VectorIterator> range_del_iter(
+      new test::VectorIterator(keys, values));
+  range_del_agg.AddTombstones(std::move(range_del_iter));
+
+  std::string begin, end;
+  AppendInternalKey(&begin, {expected_range.begin, expected_range.seq, kTypeValue});
+  AppendInternalKey(&end, {expected_range.end, expected_range.seq, kTypeValue});
+  return range_del_agg.ShouldDeleteRange(begin, end, expected_range.seq);
 }
 
 }  // anonymous namespace
@@ -273,6 +298,42 @@ TEST_F(RangeDelAggregatorTest, MergingIteratorSeek) {
   it->Seek("c");
   VerifyRangeDelIter(it.get(),
                      {{"c", "d", 20}, {"e", "f", 20}, {"f", "g", 10}});
+}
+
+TEST_F(RangeDelAggregatorTest, ShouldDeleteRange) {
+  ASSERT_TRUE(ShouldDeleteRange(
+      {{"a", "c", 10}},
+      {"a", "b", 9}));
+  ASSERT_TRUE(ShouldDeleteRange(
+      {{"a", "c", 10}},
+      {"a", "a", 9}));
+  ASSERT_FALSE(ShouldDeleteRange(
+      {{"a", "c", 10}},
+      {"b", "a", 9}));
+  ASSERT_FALSE(ShouldDeleteRange(
+      {{"a", "c", 10}},
+      {"a", "b", 10}));
+  ASSERT_FALSE(ShouldDeleteRange(
+      {{"a", "c", 10}},
+      {"a", "c", 9}));
+  ASSERT_FALSE(ShouldDeleteRange(
+      {{"b", "c", 10}},
+      {"a", "b", 9}));
+  ASSERT_TRUE(ShouldDeleteRange(
+      {{"a", "b", 10}, {"b", "d", 20}},
+      {"a", "c", 9}));
+  ASSERT_FALSE(ShouldDeleteRange(
+      {{"a", "b", 10}, {"b", "d", 20}},
+      {"a", "c", 15}));
+  ASSERT_FALSE(ShouldDeleteRange(
+      {{"a", "b", 10}, {"c", "e", 20}},
+      {"a", "d", 9}));
+  ASSERT_TRUE(ShouldDeleteRange(
+      {{"a", "b", 10}, {"c", "e", 20}},
+      {"c", "d", 15}));
+  ASSERT_FALSE(ShouldDeleteRange(
+      {{"a", "b", 10}, {"c", "e", 20}},
+      {"c", "d", 20}));
 }
 
 }  // namespace rocksdb

--- a/db/range_del_aggregator_test.cc
+++ b/db/range_del_aggregator_test.cc
@@ -19,6 +19,7 @@ namespace {
 struct ExpectedPoint {
   Slice begin;
   SequenceNumber seq;
+  bool expectAlive;
 };
 
 struct ExpectedRange {
@@ -35,7 +36,9 @@ enum Direction {
 static auto icmp = InternalKeyComparator(BytewiseComparator());
 
 void AddTombstones(RangeDelAggregator* range_del_agg,
-                   const std::vector<RangeTombstone>& range_dels) {
+                   const std::vector<RangeTombstone>& range_dels,
+                   const InternalKey* smallest = nullptr,
+                   const InternalKey* largest = nullptr) {
   std::vector<std::string> keys, values;
   for (const auto& range_del : range_dels) {
     auto key_and_value = range_del.Serialize();
@@ -44,7 +47,7 @@ void AddTombstones(RangeDelAggregator* range_del_agg,
   }
   std::unique_ptr<test::VectorIterator> range_del_iter(
       new test::VectorIterator(keys, values));
-  range_del_agg->AddTombstones(std::move(range_del_iter));
+  range_del_agg->AddTombstones(std::move(range_del_iter), smallest, largest);
 }
 
 void VerifyTombstonesEq(const RangeTombstone& a, const RangeTombstone& b) {
@@ -68,7 +71,9 @@ void VerifyRangeDelIter(
 void VerifyRangeDels(
     const std::vector<RangeTombstone>& range_dels_in,
     const std::vector<ExpectedPoint>& expected_points,
-    const std::vector<RangeTombstone>& expected_collapsed_range_dels) {
+    const std::vector<RangeTombstone>& expected_collapsed_range_dels,
+    const InternalKey* smallest = nullptr,
+    const InternalKey* largest = nullptr) {
   // Test same result regardless of which order the range deletions are added
   // and regardless of collapsed mode.
   for (bool collapsed : {false, true}) {
@@ -79,7 +84,7 @@ void VerifyRangeDels(
       if (dir == kReverse) {
         std::reverse(range_dels.begin(), range_dels.end());
       }
-      AddTombstones(&range_del_agg, range_dels);
+      AddTombstones(&range_del_agg, range_dels, smallest, largest);
 
       auto mode = RangeDelPositioningMode::kFullScan;
       if (collapsed) {
@@ -94,22 +99,29 @@ void VerifyRangeDels(
         ASSERT_FALSE(range_del_agg.ShouldDelete(parsed_key, mode));
         if (parsed_key.sequence > 0) {
           --parsed_key.sequence;
-          ASSERT_TRUE(range_del_agg.ShouldDelete(parsed_key, mode));
+          if (expected_point.expectAlive) {
+            ASSERT_FALSE(range_del_agg.ShouldDelete(parsed_key, mode));
+          } else {
+            ASSERT_TRUE(range_del_agg.ShouldDelete(parsed_key, mode));
+          }
         }
       }
 
       if (collapsed) {
         range_dels = expected_collapsed_range_dels;
-      } else {
-        // Tombstones in an uncollapsed map are presented in start key order.
-        // Tombstones with the same start key are presented in insertion order.
+        VerifyRangeDelIter(range_del_agg.NewIterator().get(), range_dels);
+      } else if (smallest == nullptr && largest == nullptr) {
+        // Tombstones in an uncollapsed map are presented in start key
+        // order. Tombstones with the same start key are presented in
+        // insertion order. We don't handle tombstone truncation here, so the
+        // verification is only performed if no truncation was requested.
         std::stable_sort(range_dels.begin(), range_dels.end(),
                          [&](const RangeTombstone& a, const RangeTombstone& b) {
                            return icmp.user_comparator()->Compare(
                                       a.start_key_, b.start_key_) < 0;
                          });
+        VerifyRangeDelIter(range_del_agg.NewIterator().get(), range_dels);
       }
-      VerifyRangeDelIter(range_del_agg.NewIterator().get(), range_dels);
     }
   }
 
@@ -389,6 +401,19 @@ TEST_F(RangeDelAggregatorTest, GetTombstone) {
       {{"a", "c", 10}, {"e", "h", 20}},
       {"e", 9},
       {"e", "h", 20});
+}
+
+TEST_F(RangeDelAggregatorTest, TruncateTombstones) {
+  const InternalKey smallest("b", 1, kTypeRangeDeletion);
+  const InternalKey largest("e", kMaxSequenceNumber, kTypeRangeDeletion);
+  VerifyRangeDels(
+      {{"a", "c", 10}, {"d", "f", 10}},
+      {{"a", 10, true},  // truncated
+       {"b", 10, false}, // not truncated
+       {"d", 10, false}, // not truncated
+       {"e", 10, true}}, // truncated
+      {{"b", "c", 10}, {"d", "e", 10}},
+      &smallest, &largest);
 }
 
 }  // namespace rocksdb

--- a/db/range_del_aggregator_test.cc
+++ b/db/range_del_aggregator_test.cc
@@ -26,45 +26,10 @@ enum Direction {
   kReverse,
 };
 
-void VerifyRangeDels(const std::vector<RangeTombstone>& range_dels,
-                     const std::vector<ExpectedPoint>& expected_points) {
-  auto icmp = InternalKeyComparator(BytewiseComparator());
-  // Test same result regardless of which order the range deletions are added.
-  for (Direction dir : {kForward, kReverse}) {
-    RangeDelAggregator range_del_agg(icmp, {} /* snapshots */, true);
-    std::vector<std::string> keys, values;
-    for (const auto& range_del : range_dels) {
-      auto key_and_value = range_del.Serialize();
-      keys.push_back(key_and_value.first.Encode().ToString());
-      values.push_back(key_and_value.second.ToString());
-    }
-    if (dir == kReverse) {
-      std::reverse(keys.begin(), keys.end());
-      std::reverse(values.begin(), values.end());
-    }
-    std::unique_ptr<test::VectorIterator> range_del_iter(
-        new test::VectorIterator(keys, values));
-    range_del_agg.AddTombstones(std::move(range_del_iter));
+static auto icmp = InternalKeyComparator(BytewiseComparator());
 
-    for (const auto expected_point : expected_points) {
-      ParsedInternalKey parsed_key;
-      parsed_key.user_key = expected_point.begin;
-      parsed_key.sequence = expected_point.seq;
-      parsed_key.type = kTypeValue;
-      ASSERT_FALSE(range_del_agg.ShouldDelete(
-          parsed_key,
-          RangeDelAggregator::RangePositioningMode::kForwardTraversal));
-      if (parsed_key.sequence > 0) {
-        --parsed_key.sequence;
-        ASSERT_TRUE(range_del_agg.ShouldDelete(
-            parsed_key,
-            RangeDelAggregator::RangePositioningMode::kForwardTraversal));
-      }
-    }
-  }
-
-  RangeDelAggregator range_del_agg(icmp, {} /* snapshots */,
-                                   false /* collapse_deletions */);
+void AddTombstones(RangeDelAggregator* range_del_agg,
+                   const std::vector<RangeTombstone>& range_dels) {
   std::vector<std::string> keys, values;
   for (const auto& range_del : range_dels) {
     auto key_and_value = range_del.Serialize();
@@ -73,7 +38,78 @@ void VerifyRangeDels(const std::vector<RangeTombstone>& range_dels,
   }
   std::unique_ptr<test::VectorIterator> range_del_iter(
       new test::VectorIterator(keys, values));
-  range_del_agg.AddTombstones(std::move(range_del_iter));
+  range_del_agg->AddTombstones(std::move(range_del_iter));
+}
+
+void VerifyTombstonesEq(const RangeTombstone& a, const RangeTombstone& b) {
+  ASSERT_EQ(a.seq_, b.seq_);
+  ASSERT_EQ(a.start_key_, b.start_key_);
+  ASSERT_EQ(a.end_key_, b.end_key_);
+}
+
+void VerifyRangeDelIter(
+    RangeDelIterator* range_del_iter,
+    const std::vector<RangeTombstone>& expected_range_dels) {
+  size_t i = 0;
+  for (; range_del_iter->Valid() && i < expected_range_dels.size();
+       range_del_iter->Next(), i++) {
+    VerifyTombstonesEq(expected_range_dels[i], range_del_iter->Tombstone());
+  }
+  ASSERT_EQ(expected_range_dels.size(), i);
+  ASSERT_FALSE(range_del_iter->Valid());
+}
+
+void VerifyRangeDels(
+    const std::vector<RangeTombstone>& range_dels_in,
+    const std::vector<ExpectedPoint>& expected_points,
+    const std::vector<RangeTombstone>& expected_collapsed_range_dels) {
+  // Test same result regardless of which order the range deletions are added
+  // and regardless of collapsed mode.
+  for (bool collapsed : {false, true}) {
+    for (Direction dir : {kForward, kReverse}) {
+      RangeDelAggregator range_del_agg(icmp, {} /* snapshots */, collapsed);
+
+      std::vector<RangeTombstone> range_dels = range_dels_in;
+      if (dir == kReverse) {
+        std::reverse(range_dels.begin(), range_dels.end());
+      }
+      AddTombstones(&range_del_agg, range_dels);
+
+      auto mode = RangeDelPositioningMode::kFullScan;
+      if (collapsed) {
+        mode = RangeDelPositioningMode::kForwardTraversal;
+      }
+
+      for (const auto expected_point : expected_points) {
+        ParsedInternalKey parsed_key;
+        parsed_key.user_key = expected_point.begin;
+        parsed_key.sequence = expected_point.seq;
+        parsed_key.type = kTypeValue;
+        ASSERT_FALSE(range_del_agg.ShouldDelete(parsed_key, mode));
+        if (parsed_key.sequence > 0) {
+          --parsed_key.sequence;
+          ASSERT_TRUE(range_del_agg.ShouldDelete(parsed_key, mode));
+        }
+      }
+
+      if (collapsed) {
+        range_dels = expected_collapsed_range_dels;
+      } else {
+        // Tombstones in an uncollapsed map are presented in start key order.
+        // Tombstones with the same start key are presented in insertion order.
+        std::stable_sort(range_dels.begin(), range_dels.end(),
+                         [&](const RangeTombstone& a, const RangeTombstone& b) {
+                           return icmp.user_comparator()->Compare(
+                                      a.start_key_, b.start_key_) < 0;
+                         });
+      }
+      VerifyRangeDelIter(range_del_agg.NewIterator().get(), range_dels);
+    }
+  }
+
+  RangeDelAggregator range_del_agg(icmp, {} /* snapshots */,
+                                   false /* collapse_deletions */);
+  AddTombstones(&range_del_agg, range_dels_in);
   for (size_t i = 1; i < expected_points.size(); ++i) {
     bool overlapped = range_del_agg.IsRangeOverlapped(
         expected_points[i - 1].begin, expected_points[i].begin);
@@ -87,60 +123,69 @@ void VerifyRangeDels(const std::vector<RangeTombstone>& range_dels,
 
 }  // anonymous namespace
 
-TEST_F(RangeDelAggregatorTest, Empty) { VerifyRangeDels({}, {{"a", 0}}); }
+TEST_F(RangeDelAggregatorTest, Empty) { VerifyRangeDels({}, {{"a", 0}}, {}); }
 
 TEST_F(RangeDelAggregatorTest, SameStartAndEnd) {
-  VerifyRangeDels({{"a", "a", 5}}, {{" ", 0}, {"a", 0}, {"b", 0}});
+  VerifyRangeDels({{"a", "a", 5}}, {{" ", 0}, {"a", 0}, {"b", 0}}, {});
 }
 
 TEST_F(RangeDelAggregatorTest, Single) {
-  VerifyRangeDels({{"a", "b", 10}}, {{" ", 0}, {"a", 10}, {"b", 0}});
+  VerifyRangeDels({{"a", "b", 10}}, {{" ", 0}, {"a", 10}, {"b", 0}},
+                  {{"a", "b", 10}});
 }
 
 TEST_F(RangeDelAggregatorTest, OverlapAboveLeft) {
   VerifyRangeDels({{"a", "c", 10}, {"b", "d", 5}},
-                  {{" ", 0}, {"a", 10}, {"c", 5}, {"d", 0}});
+                  {{" ", 0}, {"a", 10}, {"c", 5}, {"d", 0}},
+                  {{"a", "c", 10}, {"c", "d", 5}});
 }
 
 TEST_F(RangeDelAggregatorTest, OverlapAboveRight) {
   VerifyRangeDels({{"a", "c", 5}, {"b", "d", 10}},
-                  {{" ", 0}, {"a", 5}, {"b", 10}, {"d", 0}});
+                  {{" ", 0}, {"a", 5}, {"b", 10}, {"d", 0}},
+                  {{"a", "b", 5}, {"b", "d", 10}});
 }
 
 TEST_F(RangeDelAggregatorTest, OverlapAboveMiddle) {
   VerifyRangeDels({{"a", "d", 5}, {"b", "c", 10}},
-                  {{" ", 0}, {"a", 5}, {"b", 10}, {"c", 5}, {"d", 0}});
+                  {{" ", 0}, {"a", 5}, {"b", 10}, {"c", 5}, {"d", 0}},
+                  {{"a", "b", 5}, {"b", "c", 10}, {"c", "d", 5}});
 }
 
 TEST_F(RangeDelAggregatorTest, OverlapFully) {
   VerifyRangeDels({{"a", "d", 10}, {"b", "c", 5}},
-                  {{" ", 0}, {"a", 10}, {"d", 0}});
+                  {{" ", 0}, {"a", 10}, {"d", 0}}, {{"a", "d", 10}});
 }
 
 TEST_F(RangeDelAggregatorTest, OverlapPoint) {
   VerifyRangeDels({{"a", "b", 5}, {"b", "c", 10}},
-                  {{" ", 0}, {"a", 5}, {"b", 10}, {"c", 0}});
+                  {{" ", 0}, {"a", 5}, {"b", 10}, {"c", 0}},
+                  {{"a", "b", 5}, {"b", "c", 10}});
 }
 
 TEST_F(RangeDelAggregatorTest, SameStartKey) {
   VerifyRangeDels({{"a", "c", 5}, {"a", "b", 10}},
-                  {{" ", 0}, {"a", 10}, {"b", 5}, {"c", 0}});
+                  {{" ", 0}, {"a", 10}, {"b", 5}, {"c", 0}},
+                  {{"a", "b", 10}, {"b", "c", 5}});
 }
 
 TEST_F(RangeDelAggregatorTest, SameEndKey) {
   VerifyRangeDels({{"a", "d", 5}, {"b", "d", 10}},
-                  {{" ", 0}, {"a", 5}, {"b", 10}, {"d", 0}});
+                  {{" ", 0}, {"a", 5}, {"b", 10}, {"d", 0}},
+                  {{"a", "b", 5}, {"b", "d", 10}});
 }
 
 TEST_F(RangeDelAggregatorTest, GapsBetweenRanges) {
-  VerifyRangeDels({{"a", "b", 5}, {"c", "d", 10}, {"e", "f", 15}}, {{" ", 0},
-                                                                    {"a", 5},
-                                                                    {"b", 0},
-                                                                    {"c", 10},
-                                                                    {"d", 0},
-                                                                    {"da", 0},
-                                                                    {"e", 15},
-                                                                    {"f", 0}});
+  VerifyRangeDels({{"a", "b", 5}, {"c", "d", 10}, {"e", "f", 15}},
+                  {{" ", 0},
+                   {"a", 5},
+                   {"b", 0},
+                   {"c", 10},
+                   {"d", 0},
+                   {"da", 0},
+                   {"e", 15},
+                   {"f", 0}},
+                  {{"a", "b", 5}, {"c", "d", 10}, {"e", "f", 15}});
 }
 
 // Note the Cover* tests also test cases where tombstones are inserted under a
@@ -148,31 +193,86 @@ TEST_F(RangeDelAggregatorTest, GapsBetweenRanges) {
 TEST_F(RangeDelAggregatorTest, CoverMultipleFromLeft) {
   VerifyRangeDels(
       {{"b", "d", 5}, {"c", "f", 10}, {"e", "g", 15}, {"a", "f", 20}},
-      {{" ", 0}, {"a", 20}, {"f", 15}, {"g", 0}});
+      {{" ", 0}, {"a", 20}, {"f", 15}, {"g", 0}},
+      {{"a", "f", 20}, {"f", "g", 15}});
 }
 
 TEST_F(RangeDelAggregatorTest, CoverMultipleFromRight) {
   VerifyRangeDels(
       {{"b", "d", 5}, {"c", "f", 10}, {"e", "g", 15}, {"c", "h", 20}},
-      {{" ", 0}, {"b", 5}, {"c", 20}, {"h", 0}});
+      {{" ", 0}, {"b", 5}, {"c", 20}, {"h", 0}},
+      {{"b", "c", 5}, {"c", "h", 20}});
 }
 
 TEST_F(RangeDelAggregatorTest, CoverMultipleFully) {
   VerifyRangeDels(
       {{"b", "d", 5}, {"c", "f", 10}, {"e", "g", 15}, {"a", "h", 20}},
-      {{" ", 0}, {"a", 20}, {"h", 0}});
+      {{" ", 0}, {"a", 20}, {"h", 0}}, {{"a", "h", 20}});
 }
 
 TEST_F(RangeDelAggregatorTest, AlternateMultipleAboveBelow) {
   VerifyRangeDels(
       {{"b", "d", 15}, {"c", "f", 10}, {"e", "g", 20}, {"a", "h", 5}},
-      {{" ", 0},
-       {"a", 5},
-       {"b", 15},
-       {"d", 10},
-       {"e", 20},
-       {"g", 5},
-       {"h", 0}});
+      {{" ", 0}, {"a", 5}, {"b", 15}, {"d", 10}, {"e", 20}, {"g", 5}, {"h", 0}},
+      {{"a", "b", 5},
+       {"b", "d", 15},
+       {"d", "e", 10},
+       {"e", "g", 20},
+       {"g", "h", 5}});
+}
+
+TEST_F(RangeDelAggregatorTest, MergingIteratorAllEmptyStripes) {
+  for (bool collapsed : {true, false}) {
+    RangeDelAggregator range_del_agg(icmp, {1, 2}, collapsed);
+    VerifyRangeDelIter(range_del_agg.NewIterator().get(), {});
+  }
+}
+
+TEST_F(RangeDelAggregatorTest, MergingIteratorOverlappingStripes) {
+  for (bool collapsed : {true, false}) {
+    RangeDelAggregator range_del_agg(icmp, {5, 15, 25, 35}, collapsed);
+    AddTombstones(
+        &range_del_agg,
+        {{"d", "e", 10}, {"aa", "b", 20}, {"c", "d", 30}, {"a", "b", 10}});
+    VerifyRangeDelIter(
+        range_del_agg.NewIterator().get(),
+        {{"a", "b", 10}, {"aa", "b", 20}, {"c", "d", 30}, {"d", "e", 10}});
+  }
+}
+
+TEST_F(RangeDelAggregatorTest, MergingIteratorSeek) {
+  RangeDelAggregator range_del_agg(icmp, {5, 15}, true /* collapsed */);
+  AddTombstones(&range_del_agg, {{"a", "c", 10},
+                                 {"b", "c", 11},
+                                 {"f", "g", 10},
+                                 {"c", "d", 20},
+                                 {"e", "f", 20}});
+  auto it = range_del_agg.NewIterator();
+
+  // Verify seek positioning.
+  it->Seek("");
+  VerifyTombstonesEq(it->Tombstone(), {"a", "b", 10});
+  it->Seek("a");
+  VerifyTombstonesEq(it->Tombstone(), {"a", "b", 10});
+  it->Seek("aa");
+  VerifyTombstonesEq(it->Tombstone(), {"a", "b", 10});
+  it->Seek("b");
+  VerifyTombstonesEq(it->Tombstone(), {"b", "c", 11});
+  it->Seek("c");
+  VerifyTombstonesEq(it->Tombstone(), {"c", "d", 20});
+  it->Seek("dd");
+  VerifyTombstonesEq(it->Tombstone(), {"e", "f", 20});
+  it->Seek("f");
+  VerifyTombstonesEq(it->Tombstone(), {"f", "g", 10});
+  it->Seek("g");
+  ASSERT_EQ(it->Valid(), false);
+  it->Seek("h");
+  ASSERT_EQ(it->Valid(), false);
+
+  // Verify iteration after seek.
+  it->Seek("c");
+  VerifyRangeDelIter(it.get(),
+                     {{"c", "d", 20}, {"e", "f", 20}, {"f", "g", 10}});
 }
 
 }  // namespace rocksdb

--- a/db/range_del_aggregator_test.cc
+++ b/db/range_del_aggregator_test.cc
@@ -146,6 +146,26 @@ bool ShouldDeleteRange(const std::vector<RangeTombstone>& range_dels,
   return range_del_agg.ShouldDeleteRange(begin, end, expected_range.seq);
 }
 
+void VerifyGetTombstone(const std::vector<RangeTombstone>& range_dels,
+                        const ExpectedPoint& expected_point,
+                        const RangeTombstone& expected_tombstone) {
+  RangeDelAggregator range_del_agg(icmp, {} /* snapshots */, true);
+  std::vector<std::string> keys, values;
+  for (const auto& range_del : range_dels) {
+    auto key_and_value = range_del.Serialize();
+    keys.push_back(key_and_value.first.Encode().ToString());
+    values.push_back(key_and_value.second.ToString());
+  }
+  std::unique_ptr<test::VectorIterator> range_del_iter(
+      new test::VectorIterator(keys, values));
+  range_del_agg.AddTombstones(std::move(range_del_iter));
+
+  auto tombstone = range_del_agg.GetTombstone(expected_point.begin, expected_point.seq);
+  ASSERT_EQ(expected_tombstone.start_key_.ToString(), tombstone.start_key_.ToString());
+  ASSERT_EQ(expected_tombstone.end_key_.ToString(), tombstone.end_key_.ToString());
+  ASSERT_EQ(expected_tombstone.seq_, tombstone.seq_);
+}
+
 }  // anonymous namespace
 
 TEST_F(RangeDelAggregatorTest, Empty) { VerifyRangeDels({}, {{"a", 0}}, {}); }
@@ -334,6 +354,41 @@ TEST_F(RangeDelAggregatorTest, ShouldDeleteRange) {
   ASSERT_FALSE(ShouldDeleteRange(
       {{"a", "b", 10}, {"c", "e", 20}},
       {"c", "d", 20}));
+}
+
+TEST_F(RangeDelAggregatorTest, GetTombstone) {
+  VerifyGetTombstone(
+      {{"b", "d", 10}},
+      {"b", 9},
+      {"b", "d", 10});
+  VerifyGetTombstone(
+      {{"b", "d", 10}},
+      {"b", 20},
+      {"b", "d", 0});
+  VerifyGetTombstone(
+      {{"b", "d", 10}},
+      {"a", 9},
+      {"", "b", 0});
+  VerifyGetTombstone(
+      {{"b", "d", 10}},
+      {"d", 9},
+      {"d", "", 0});
+  VerifyGetTombstone(
+      {{"a", "c", 10}, {"e", "h", 20}},
+      {"d", 9},
+      {"c", "e", 0});
+  VerifyGetTombstone(
+      {{"a", "c", 10}, {"e", "h", 20}},
+      {"b", 9},
+      {"a", "c", 10});
+  VerifyGetTombstone(
+      {{"a", "c", 10}, {"e", "h", 20}},
+      {"e", 9},
+      {"e", "h", 20});
+  VerifyGetTombstone(
+      {{"a", "c", 10}, {"e", "h", 20}},
+      {"e", 9},
+      {"e", "h", 20});
 }
 
 }  // namespace rocksdb

--- a/db/repair.cc
+++ b/db/repair.cc
@@ -498,7 +498,7 @@ class Repairer {
     }
     if (status.ok()) {
       InternalIterator* iter = table_cache_->NewIterator(
-          ReadOptions(), env_options_, cfd->internal_comparator(), t->meta.fd,
+          ReadOptions(), env_options_, cfd->internal_comparator(), t->meta,
           nullptr /* range_del_agg */);
       bool empty = true;
       ParsedInternalKey parsed;

--- a/db/table_cache.cc
+++ b/db/table_cache.cc
@@ -271,43 +271,6 @@ InternalIterator* TableCache::NewIterator(
   return result;
 }
 
-InternalIterator* TableCache::NewRangeTombstoneIterator(
-    const ReadOptions& options, const EnvOptions& env_options,
-    const InternalKeyComparator& icomparator, const FileDescriptor& fd,
-    HistogramImpl* file_read_hist, bool skip_filters, int level) {
-  Status s;
-  Cache::Handle* handle = nullptr;
-  TableReader* table_reader = fd.table_reader;
-  if (table_reader == nullptr) {
-    s = FindTable(env_options, icomparator, fd, &handle,
-                  options.read_tier == kBlockCacheTier /* no_io */,
-                  true /* record read_stats */, file_read_hist, skip_filters,
-                  level);
-    if (s.ok()) {
-      table_reader = GetTableReaderFromHandle(handle);
-    }
-  }
-  InternalIterator* result = nullptr;
-  if (s.ok()) {
-    result = table_reader->NewRangeTombstoneIterator(options);
-    if (result != nullptr) {
-      if (handle != nullptr) {
-        result->RegisterCleanup(&UnrefEntry, cache_, handle);
-      }
-    }
-  }
-  if (result == nullptr && handle != nullptr) {
-    // the range deletion block didn't exist, or there was a failure between
-    // getting handle and getting iterator.
-    ReleaseHandle(handle);
-  }
-  if (!s.ok()) {
-    assert(result == nullptr);
-    result = NewErrorInternalIterator(s);
-  }
-  return result;
-}
-
 Status TableCache::Get(const ReadOptions& options,
                        const InternalKeyComparator& internal_comparator,
                        const FileDescriptor& fd, const Slice& k,

--- a/db/table_cache.cc
+++ b/db/table_cache.cc
@@ -247,13 +247,15 @@ InternalIterator* TableCache::NewIterator(
     }
   }
   if (s.ok() && range_del_agg != nullptr && !options.ignore_range_deletions) {
-    std::unique_ptr<InternalIterator> range_del_iter(
-        table_reader->NewRangeTombstoneIterator(options));
-    if (range_del_iter != nullptr) {
-      s = range_del_iter->status();
-    }
-    if (s.ok()) {
-      s = range_del_agg->AddTombstones(std::move(range_del_iter));
+    if (range_del_agg->AddFile(fd.GetNumber())) {
+      std::unique_ptr<InternalIterator> range_del_iter(
+          table_reader->NewRangeTombstoneIterator(options));
+      if (range_del_iter != nullptr) {
+        s = range_del_iter->status();
+      }
+      if (s.ok()) {
+        s = range_del_agg->AddTombstones(std::move(range_del_iter));
+      }
     }
   }
 

--- a/db/table_cache.cc
+++ b/db/table_cache.cc
@@ -229,7 +229,9 @@ InternalIterator* TableCache::NewIterator(
         !options.table_filter(*table_reader->GetTableProperties())) {
       result = NewEmptyInternalIterator(arena);
     } else {
-      result = table_reader->NewIterator(options, arena, skip_filters);
+      result = table_reader->NewIterator(
+          options, range_del_agg, nullptr /* file_meta */,
+          arena, skip_filters);
     }
     if (create_new_table_reader) {
       assert(handle == nullptr);

--- a/db/table_cache.cc
+++ b/db/table_cache.cc
@@ -170,7 +170,7 @@ Status TableCache::FindTable(const EnvOptions& env_options,
 
 InternalIterator* TableCache::NewIterator(
     const ReadOptions& options, const EnvOptions& env_options,
-    const InternalKeyComparator& icomparator, const FileDescriptor& fd,
+    const InternalKeyComparator& icomparator, const FileMetaData& file_meta,
     RangeDelAggregator* range_del_agg, TableReader** table_reader_ptr,
     HistogramImpl* file_read_hist, bool for_compaction, Arena* arena,
     bool skip_filters, int level) {
@@ -201,6 +201,7 @@ InternalIterator* TableCache::NewIterator(
     create_new_table_reader = readahead > 0;
   }
 
+  auto& fd = file_meta.fd;
   if (create_new_table_reader) {
     unique_ptr<TableReader> table_reader_unique_ptr;
     s = GetTableReader(
@@ -256,7 +257,10 @@ InternalIterator* TableCache::NewIterator(
         s = range_del_iter->status();
       }
       if (s.ok()) {
-        s = range_del_agg->AddTombstones(std::move(range_del_iter));
+        s = range_del_agg->AddTombstones(
+            std::move(range_del_iter),
+            &file_meta.smallest,
+            &file_meta.largest);
       }
     }
   }
@@ -273,9 +277,10 @@ InternalIterator* TableCache::NewIterator(
 
 Status TableCache::Get(const ReadOptions& options,
                        const InternalKeyComparator& internal_comparator,
-                       const FileDescriptor& fd, const Slice& k,
+                       const FileMetaData& file_meta, const Slice& k,
                        GetContext* get_context, HistogramImpl* file_read_hist,
                        bool skip_filters, int level) {
+  auto& fd = file_meta.fd;
   std::string* row_cache_entry = nullptr;
   bool done = false;
 #ifndef ROCKSDB_LITE
@@ -356,7 +361,9 @@ Status TableCache::Get(const ReadOptions& options,
       }
       if (s.ok()) {
         s = get_context->range_del_agg()->AddTombstones(
-            std::move(range_del_iter));
+            std::move(range_del_iter),
+            &file_meta.smallest,
+            &file_meta.largest);
       }
     }
     if (s.ok()) {

--- a/db/table_cache.h
+++ b/db/table_cache.h
@@ -58,12 +58,6 @@ class TableCache {
       HistogramImpl* file_read_hist = nullptr, bool for_compaction = false,
       Arena* arena = nullptr, bool skip_filters = false, int level = -1);
 
-  InternalIterator* NewRangeTombstoneIterator(
-      const ReadOptions& options, const EnvOptions& toptions,
-      const InternalKeyComparator& internal_comparator,
-      const FileDescriptor& file_fd, HistogramImpl* file_read_hist,
-      bool skip_filters, int level);
-
   // If a seek to internal key "k" in specified file finds an entry,
   // call (*handle_result)(arg, found_key, found_value) repeatedly until
   // it returns false.

--- a/db/table_cache.h
+++ b/db/table_cache.h
@@ -53,7 +53,7 @@ class TableCache {
   InternalIterator* NewIterator(
       const ReadOptions& options, const EnvOptions& toptions,
       const InternalKeyComparator& internal_comparator,
-      const FileDescriptor& file_fd, RangeDelAggregator* range_del_agg,
+      const FileMetaData& file_meta, RangeDelAggregator* range_del_agg,
       TableReader** table_reader_ptr = nullptr,
       HistogramImpl* file_read_hist = nullptr, bool for_compaction = false,
       Arena* arena = nullptr, bool skip_filters = false, int level = -1);
@@ -68,7 +68,7 @@ class TableCache {
   // @param level The level this table is at, -1 for "not set / don't know"
   Status Get(const ReadOptions& options,
              const InternalKeyComparator& internal_comparator,
-             const FileDescriptor& file_fd, const Slice& k,
+             const FileMetaData& file_meta, const Slice& k,
              GetContext* get_context, HistogramImpl* file_read_hist = nullptr,
              bool skip_filters = false, int level = -1);
 

--- a/db/version_edit.h
+++ b/db/version_edit.h
@@ -131,6 +131,21 @@ struct FileMetaData {
     smallest_seqno = std::min(smallest_seqno, seqno);
     largest_seqno = std::max(largest_seqno, seqno);
   }
+
+  // Unlike UpdateBoundaries, ranges do not need to be presented in any
+  // particular order.
+  void UpdateBoundariesForRange(const InternalKey& start,
+                                const InternalKey& end, SequenceNumber seqno,
+                                const InternalKeyComparator& icmp) {
+    if (smallest.size() == 0 || icmp.Compare(start, smallest) < 0) {
+      smallest = start;
+    }
+    if (largest.size() == 0 || icmp.Compare(largest, end) < 0) {
+      largest = end;
+    }
+    smallest_seqno = std::min(smallest_seqno, seqno);
+    largest_seqno = std::max(largest_seqno, seqno);
+  }
 };
 
 // A compressed copy of file meta data that just contain minimum data needed

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -541,8 +541,8 @@ class LevelIterator final : public InternalIterator {
     assert(file_index_ < flevel_->num_files);
     auto file_meta = flevel_->files[file_index_];
     // Check to see if every key in the sstable is covered by a range
-    // tombstone. SkipEmptyFile{Forward,Backward} will take care of
-    // skipping over an "empty" file if we return null.
+    // tombstone. SkipEmptyFile{Forward,Backward} will take care of skipping
+    // over an "empty" file if we return null.
     if (range_del_agg_->ShouldDeleteRange(file_meta.smallest_key, file_meta.largest_key,
                                           file_meta.file_metadata->largest_seqno)) {
       return nullptr;

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -553,7 +553,8 @@ class LevelIterator final : public InternalIterator {
     }
 
     return table_cache_->NewIterator(
-        read_options_, env_options_, icomparator_, file_meta.fd, range_del_agg_,
+        read_options_, env_options_, icomparator_, *file_meta.file_metadata,
+        range_del_agg_,
         nullptr /* don't need reference to table */, file_read_hist_,
         for_compaction_, nullptr /* arena */, skip_filters_, level_);
   }
@@ -1034,7 +1035,7 @@ void Version::AddIteratorsForLevel(const ReadOptions& read_options,
       if (!range_del_agg->ShouldDeleteRange(
               file.smallest_key, file.largest_key, file.file_metadata->largest_seqno)) {
         merge_iter_builder->AddIterator(cfd_->table_cache()->NewIterator(
-            read_options, soptions, cfd_->internal_comparator(), file.fd,
+            read_options, soptions, cfd_->internal_comparator(), *file.file_metadata,
             range_del_agg, nullptr, cfd_->internal_stats()->GetFileReadHist(0),
             false, arena, false /* skip_filters */, 0 /* level */));
       }
@@ -1087,7 +1088,7 @@ Status Version::OverlapWithLevelIterator(const ReadOptions& read_options,
         continue;
       }
       ScopedArenaIterator iter(cfd_->table_cache()->NewIterator(
-          read_options, env_options, cfd_->internal_comparator(), file->fd,
+          read_options, env_options, cfd_->internal_comparator(), *file->file_metadata,
           &range_del_agg, nullptr, cfd_->internal_stats()->GetFileReadHist(0),
           false, &arena, false /* skip_filters */, 0 /* level */));
       status = OverlapWithIterator(
@@ -1228,7 +1229,7 @@ void Version::Get(const ReadOptions& read_options, const LookupKey& k,
     }
 
     *status = table_cache_->Get(
-        read_options, *internal_comparator(), f->fd, ikey, &get_context,
+        read_options, *internal_comparator(), *f->file_metadata, ikey, &get_context,
         cfd_->internal_stats()->GetFileReadHist(fp.GetHitFileLevel()),
         IsFilterSkipped(static_cast<int>(fp.GetHitFileLevel()),
                         fp.IsHitFileLastInLevel()),
@@ -3886,8 +3887,8 @@ uint64_t VersionSet::ApproximateSize(Version* v, const FdWithKeyRange& f,
     // approximate offset of "key" within the table.
     TableReader* table_reader_ptr;
     InternalIterator* iter = v->cfd_->table_cache()->NewIterator(
-        ReadOptions(), v->env_options_, v->cfd_->internal_comparator(), f.fd,
-        nullptr /* range_del_agg */, &table_reader_ptr);
+        ReadOptions(), v->env_options_, v->cfd_->internal_comparator(),
+        *f.file_metadata, nullptr /* range_del_agg */, &table_reader_ptr);
     if (table_reader_ptr != nullptr) {
       result = table_reader_ptr->ApproximateOffsetOf(key);
     }
@@ -3966,7 +3967,7 @@ InternalIterator* VersionSet::MakeInputIterator(
         for (size_t i = 0; i < flevel->num_files; i++) {
           list[num++] = cfd->table_cache()->NewIterator(
               read_options, env_options_compactions, cfd->internal_comparator(),
-              flevel->files[i].fd, range_del_agg,
+              *flevel->files[i].file_metadata, range_del_agg,
               nullptr /* table_reader_ptr */,
               nullptr /* no per level latency histogram */,
               true /* for_compaction */, nullptr /* arena */,

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -2050,8 +2050,8 @@ void VersionStorageInfo::GetOverlappingInputs(
     *file_index = -1;
   }
   const Comparator* user_cmp = user_comparator_;
-  if (begin != nullptr && end != nullptr && level > 0) {
-    GetOverlappingInputsRangeBinarySearch(level, user_begin, user_end, inputs,
+  if (level > 0) {
+    GetOverlappingInputsRangeBinarySearch(level, begin, end, inputs,
                                           hint_index, file_index);
     return;
   }
@@ -2106,23 +2106,72 @@ void VersionStorageInfo::GetCleanInputsWithinInterval(
     return;
   }
 
-  Slice user_begin, user_end;
   const auto& level_files = level_files_brief_[level];
   if (begin == nullptr) {
-    user_begin = ExtractUserKey(level_files.files[0].smallest_key);
-  } else {
-    user_begin = begin->user_key();
+    begin = &level_files.files[0].file_metadata->smallest;
   }
   if (end == nullptr) {
-    user_end = ExtractUserKey(
-        level_files.files[level_files.num_files - 1].largest_key);
-  } else {
-    user_end = end->user_key();
+    end = &level_files.files[level_files.num_files - 1].file_metadata->largest;
   }
-  GetOverlappingInputsRangeBinarySearch(level, user_begin, user_end, inputs,
+
+  GetOverlappingInputsRangeBinarySearch(level, begin, end, inputs,
                                         hint_index, file_index,
                                         true /* within_interval */);
 }
+
+namespace {
+
+const uint64_t kRangeTombstoneSentinel =
+    PackSequenceAndType(kMaxSequenceNumber, kTypeRangeDeletion);
+
+// Utility for comparing sstable boundary keys. Returns -1 if either a or b is
+// null which provides the property that a==null indicates a key that is less
+// than any key and b==null indicates a key that is greater than any key. Note
+// that the comparison is performed primarily on the user-key portion of the
+// key. If the user-keys compare equal, an additional test is made to sort
+// range tombstone sentinel keys before other keys with the same user-key. The
+// result is that 2 user-keys will compare equal if they differ purely on
+// their sequence number and value, but the range tombstone sentinel for that
+// user-key will compare not equal. This is necessary because the range
+// tombstone sentinel key is set as the largest key for an sstable even though
+// that key never appears in the database. We don't want adjacent sstables to
+// be considered overlapping if they are separated by the range tombstone
+// sentinel.
+int sstableKeyCompare(const Comparator* user_cmp,
+                      const InternalKey& a, const InternalKey& b) {
+  auto c = user_cmp->Compare(a.user_key(), b.user_key());
+  if (c != 0) {
+    return c;
+  }
+  auto a_footer = ExtractInternalKeyFooter(a.Encode());
+  auto b_footer = ExtractInternalKeyFooter(b.Encode());
+  if (a_footer == kRangeTombstoneSentinel) {
+    if (b_footer != kRangeTombstoneSentinel) {
+      return -1;
+    }
+  } else if (b_footer == kRangeTombstoneSentinel) {
+    return 1;
+  }
+  return 0;
+}
+
+int sstableKeyCompare(const Comparator* user_cmp,
+                      const InternalKey* a, const InternalKey& b) {
+  if (a == nullptr) {
+    return -1;
+  }
+  return sstableKeyCompare(user_cmp, *a, b);
+}
+
+int sstableKeyCompare(const Comparator* user_cmp,
+                      const InternalKey& a, const InternalKey* b) {
+  if (b == nullptr) {
+    return -1;
+  }
+  return sstableKeyCompare(user_cmp, a, *b);
+}
+
+} // namespace
 
 // Store in "*inputs" all files in "level" that overlap [begin,end]
 // Employ binary search to find at least one file that overlaps the
@@ -2132,7 +2181,7 @@ void VersionStorageInfo::GetCleanInputsWithinInterval(
 // within range [begin, end]. "clean" means there is a boudnary
 // between the files in "*inputs" and the surrounding files
 void VersionStorageInfo::GetOverlappingInputsRangeBinarySearch(
-    int level, const Slice& user_begin, const Slice& user_end,
+    int level, const InternalKey* begin, const InternalKey* end,
     std::vector<FileMetaData*>* inputs, int hint_index, int* file_index,
     bool within_interval) const {
   assert(level > 0);
@@ -2140,7 +2189,7 @@ void VersionStorageInfo::GetOverlappingInputsRangeBinarySearch(
   int mid = 0;
   int max = static_cast<int>(files_[level].size()) - 1;
   bool foundOverlap = false;
-  const Comparator* user_cmp = user_comparator_;
+  auto user_cmp = user_comparator_;
 
   // if the caller already knows the index of a file that has overlap,
   // then we can skip the binary search.
@@ -2152,15 +2201,15 @@ void VersionStorageInfo::GetOverlappingInputsRangeBinarySearch(
   while (!foundOverlap && min <= max) {
     mid = (min + max)/2;
     FdWithKeyRange* f = &(level_files_brief_[level].files[mid]);
-    const Slice file_start = ExtractUserKey(f->smallest_key);
-    const Slice file_limit = ExtractUserKey(f->largest_key);
-    if ((!within_interval && user_cmp->Compare(file_limit, user_begin) < 0) ||
-        (within_interval && user_cmp->Compare(file_start, user_begin) < 0)) {
+    auto& smallest = f->file_metadata->smallest;
+    auto& largest = f->file_metadata->largest;
+    if ((!within_interval && sstableKeyCompare(user_cmp, begin, largest) > 0) ||
+        (within_interval && sstableKeyCompare(user_cmp, begin, smallest) > 0)) {
       min = mid + 1;
     } else if ((!within_interval &&
-                user_cmp->Compare(user_end, file_start) < 0) ||
+                sstableKeyCompare(user_cmp, smallest, end) > 0) ||
                (within_interval &&
-                user_cmp->Compare(user_end, file_limit) < 0)) {
+                sstableKeyCompare(user_cmp, largest, end) > 0)) {
       max = mid - 1;
     } else {
       foundOverlap = true;
@@ -2179,10 +2228,10 @@ void VersionStorageInfo::GetOverlappingInputsRangeBinarySearch(
 
   int start_index, end_index;
   if (within_interval) {
-    ExtendFileRangeWithinInterval(level, user_begin, user_end, mid, &start_index,
-                                  &end_index);
+    ExtendFileRangeWithinInterval(level, begin, end, mid,
+                                  &start_index, &end_index);
   } else {
-    ExtendFileRangeOverlappingInterval(level, user_begin, user_end, mid,
+    ExtendFileRangeOverlappingInterval(level, begin, end, mid,
                                        &start_index, &end_index);
     assert(end_index >= start_index);
   }
@@ -2199,21 +2248,28 @@ void VersionStorageInfo::GetOverlappingInputsRangeBinarySearch(
 // and forward to find all overlapping files.
 // Use FileLevel in searching, make it faster
 void VersionStorageInfo::ExtendFileRangeOverlappingInterval(
-    int level, const Slice& user_begin, const Slice& user_end,
+    int level, const InternalKey* begin, const InternalKey* end,
     unsigned int mid_index, int* start_index, int* end_index) const {
-  const Comparator* user_cmp = user_comparator_;
+  auto user_cmp = user_comparator_;
   const FdWithKeyRange* files = level_files_brief_[level].files;
 #ifndef NDEBUG
   {
     // assert that the file at mid_index overlaps with the range
     assert(mid_index < level_files_brief_[level].num_files);
     const FdWithKeyRange* f = &files[mid_index];
-    const Slice fstart = ExtractUserKey(f->smallest_key);
-    const Slice flimit = ExtractUserKey(f->largest_key);
-    if (user_cmp->Compare(fstart, user_begin) >= 0) {
-      assert(user_cmp->Compare(fstart, user_end) <= 0);
+    auto& smallest = f->file_metadata->smallest;
+    auto& largest = f->file_metadata->largest;
+    if (sstableKeyCompare(user_cmp, begin, smallest) <= 0) {
+      assert(sstableKeyCompare(user_cmp, smallest, end) <= 0);
     } else {
-      assert(user_cmp->Compare(flimit, user_begin) >= 0);
+      // fprintf(stderr, "ExtendFileRangeOverlappingInterval\n%s - %s\n%s - %s\n%d %d\n",
+      //         begin ? begin->DebugString().c_str() : "(null)",
+      //         end ? end->DebugString().c_str() : "(null)",
+      //         smallest->DebugString().c_str(),
+      //         largest->DebugString().c_str(),
+      //         sstableKeyCompare(user_cmp, smallest, begin),
+      //         sstableKeyCompare(user_cmp, largest, begin));
+      assert(sstableKeyCompare(user_cmp, begin, largest) <= 0);
     }
   }
 #endif
@@ -2225,8 +2281,8 @@ void VersionStorageInfo::ExtendFileRangeOverlappingInterval(
   // check backwards from 'mid' to lower indices
   for (int i = mid_index; i >= 0 ; i--) {
     const FdWithKeyRange* f = &files[i];
-    const Slice file_limit = ExtractUserKey(f->largest_key);
-    if (user_cmp->Compare(file_limit, user_begin) >= 0) {
+    auto& largest = f->file_metadata->largest;
+    if (sstableKeyCompare(user_cmp, begin, largest) <= 0) {
       *start_index = i;
       assert((count++, true));
     } else {
@@ -2237,8 +2293,8 @@ void VersionStorageInfo::ExtendFileRangeOverlappingInterval(
   for (unsigned int i = mid_index+1;
        i < level_files_brief_[level].num_files; i++) {
     const FdWithKeyRange* f = &files[i];
-    const Slice file_start = ExtractUserKey(f->smallest_key);
-    if (user_cmp->Compare(file_start, user_end) <= 0) {
+    auto& smallest = f->file_metadata->smallest;
+    if (sstableKeyCompare(user_cmp, smallest, end) <= 0) {
       assert((count++, true));
       *end_index = i;
     } else {
@@ -2256,39 +2312,36 @@ void VersionStorageInfo::ExtendFileRangeOverlappingInterval(
 // the clean range required.
 // Use FileLevel in searching, make it faster
 void VersionStorageInfo::ExtendFileRangeWithinInterval(
-    int level, const Slice& user_begin, const Slice& user_end,
+    int level, const InternalKey* begin, const InternalKey* end,
     unsigned int mid_index, int* start_index, int* end_index) const {
   assert(level != 0);
-  const Comparator* user_cmp = user_comparator_;
+  auto* user_cmp = user_comparator_;
   const FdWithKeyRange* files = level_files_brief_[level].files;
 #ifndef NDEBUG
   {
     // assert that the file at mid_index is within the range
     assert(mid_index < level_files_brief_[level].num_files);
     const FdWithKeyRange* f = &files[mid_index];
-    const Slice fstart = ExtractUserKey(f->smallest_key);
-    const Slice flimit = ExtractUserKey(f->largest_key);
-    assert(user_cmp->Compare(fstart, user_begin) >= 0 &&
-           user_cmp->Compare(flimit, user_end) <= 0);
+    auto& smallest = f->file_metadata->smallest;
+    auto& largest = f->file_metadata->largest;
+    assert(sstableKeyCompare(user_cmp, begin, smallest) <= 0 &&
+           sstableKeyCompare(user_cmp, largest, end) <= 0);
   }
 #endif
-  ExtendFileRangeOverlappingInterval(level, user_begin, user_end, mid_index,
+  ExtendFileRangeOverlappingInterval(level, begin, end, mid_index,
                                      start_index, end_index);
   int left = *start_index;
   int right = *end_index;
   // shrink from left to right
   while (left <= right) {
-    const Slice& first_key_in_range = ExtractUserKey(files[left].smallest_key);
-    if (user_cmp->Compare(first_key_in_range, user_begin) < 0) {
+    auto& smallest = files[left].file_metadata->smallest;
+    if (sstableKeyCompare(user_cmp, begin, smallest) > 0) {
       left++;
       continue;
     }
     if (left > 0) {  // If not first file
-      const Slice& last_key_before =
-          ExtractUserKey(files[left - 1].largest_key);
-      if (user_cmp->Equal(first_key_in_range, last_key_before)) {
-        // The first user key in range overlaps with the previous file's last
-        // key
+      auto& largest = files[left - 1].file_metadata->largest;
+      if (sstableKeyCompare(user_cmp, smallest, largest) == 0) {
         left++;
         continue;
       }
@@ -2297,16 +2350,15 @@ void VersionStorageInfo::ExtendFileRangeWithinInterval(
   }
   // shrink from right to left
   while (left <= right) {
-    const Slice last_key_in_range = ExtractUserKey(files[right].largest_key);
-    if (user_cmp->Compare(last_key_in_range, user_end) > 0) {
+    auto& largest = files[right].file_metadata->largest;
+    if (sstableKeyCompare(user_cmp, largest, end) > 0) {
       right--;
       continue;
     }
     if (right < static_cast<int>(level_files_brief_[level].num_files) -
                     1) {  // If not the last file
-      const Slice first_key_after =
-          ExtractUserKey(files[right + 1].smallest_key);
-      if (user_cmp->Equal(last_key_in_range, first_key_after)) {
+      auto& smallest = files[right + 1].file_metadata->smallest;
+      if (sstableKeyCompare(user_cmp, smallest, largest) == 0) {
         // The last user key in range overlaps with the next file's first key
         right--;
         continue;

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -540,6 +540,14 @@ class LevelIterator final : public InternalIterator {
   InternalIterator* NewFileIterator() {
     assert(file_index_ < flevel_->num_files);
     auto file_meta = flevel_->files[file_index_];
+    // Check to see if every key in the sstable is covered by a range
+    // tombstone. SkipEmptyFile{Forward,Backward} will take care of
+    // skipping over an "empty" file if we return null.
+    if (range_del_agg_->ShouldDeleteRange(file_meta.smallest_key, file_meta.largest_key,
+                                          file_meta.file_metadata->largest_seqno)) {
+      return nullptr;
+    }
+
     if (should_sample_) {
       sample_file_read_inc(file_meta.file_metadata);
     }
@@ -574,6 +582,21 @@ void LevelIterator::Seek(const Slice& target) {
 
   InitFileIterator(new_file_index);
   if (file_iter_.iter() != nullptr) {
+    // TODO(peter): Rather the seeking to target, we could use
+    // RangeDelAggregator to find the first key within the file that
+    // is not covered by a range tombstone. Something like:
+    //
+    //   first_non_deleted = range_del_agg_->SeekForward(
+    //       smallest_key, largest_key, largest_seqno);
+    //   if (target < first_non_deleted) {
+    //     target = first_non_deleted;
+    //   }
+    //
+    // This optimization applies to SeekForPrev, Next and Prev as
+    // well. For Next and Prev we'd want some way to keep track of the
+    // current tombstone. Perhaps a RangeDelAggregator::Iterator,
+    // though that would need to be stable in the presence of
+    // modifications to RangeDelAggregator tombstone_maps.
     file_iter_.Seek(target);
   }
   SkipEmptyFileForward();
@@ -588,8 +611,8 @@ void LevelIterator::SeekForPrev(const Slice& target) {
   InitFileIterator(new_file_index);
   if (file_iter_.iter() != nullptr) {
     file_iter_.SeekForPrev(target);
-    SkipEmptyFileBackward();
   }
+  SkipEmptyFileBackward();
 }
 
 void LevelIterator::SeekToFirst() {

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -197,8 +197,8 @@ class VersionStorageInfo {
 
   void GetOverlappingInputsRangeBinarySearch(
       int level,           // level > 0
-      const Slice& begin,  // nullptr means before all keys
-      const Slice& end,    // nullptr means after all keys
+      const InternalKey* begin,  // nullptr means before all keys
+      const InternalKey* end,    // nullptr means after all keys
       std::vector<FileMetaData*>* inputs,
       int hint_index,                // index of overlap file
       int* file_index,               // return index of overlap file
@@ -207,20 +207,20 @@ class VersionStorageInfo {
 
   void ExtendFileRangeOverlappingInterval(
       int level,
-      const Slice& begin,  // nullptr means before all keys
-      const Slice& end,    // nullptr means after all keys
-      unsigned int index,  // start extending from this index
-      int* startIndex,     // return the startIndex of input range
-      int* endIndex)       // return the endIndex of input range
+      const InternalKey* begin,  // nullptr means before all keys
+      const InternalKey* end,    // nullptr means after all keys
+      unsigned int index,        // start extending from this index
+      int* startIndex,           // return the startIndex of input range
+      int* endIndex)             // return the endIndex of input range
       const;
 
   void ExtendFileRangeWithinInterval(
       int level,
-      const Slice& begin,  // nullptr means before all keys
-      const Slice& end,    // nullptr means after all keys
-      unsigned int index,  // start extending from this index
-      int* startIndex,     // return the startIndex of input range
-      int* endIndex)       // return the endIndex of input range
+      const InternalKey* begin,  // nullptr means before all keys
+      const InternalKey* end,    // nullptr means after all keys
+      unsigned int index,        // start extending from this index
+      int* startIndex,           // return the startIndex of input range
+      int* endIndex)             // return the endIndex of input range
       const;
 
   // Returns true iff some file in the specified level overlaps

--- a/db/version_set_test.cc
+++ b/db/version_set_test.cc
@@ -9,6 +9,7 @@
 
 #include "db/version_set.h"
 #include "util/logging.h"
+#include "util/string_util.h"
 #include "util/testharness.h"
 #include "util/testutil.h"
 
@@ -137,6 +138,35 @@ class VersionStorageInfoTest : public testing::Test {
     f->num_deletions = 0;
     vstorage_.AddFile(level, f);
   }
+
+  void Add(int level, uint32_t file_number, const InternalKey& smallest,
+           const InternalKey& largest, uint64_t file_size = 0) {
+    assert(level < vstorage_.num_levels());
+    FileMetaData* f = new FileMetaData;
+    f->fd = FileDescriptor(file_number, 0, file_size);
+    f->smallest = smallest;
+    f->largest = largest;
+    f->compensated_file_size = file_size;
+    f->refs = 0;
+    f->num_entries = 0;
+    f->num_deletions = 0;
+    vstorage_.AddFile(level, f);
+  }
+
+  std::string GetOverlappingFiles(int level, const InternalKey& begin,
+                                  const InternalKey& end) {
+    std::vector<FileMetaData*> inputs;
+    vstorage_.GetOverlappingInputs(level, &begin, &end, &inputs);
+
+    std::string result;
+    for (size_t i = 0; i < inputs.size(); ++i) {
+      if (i > 0) {
+        result += ",";
+      }
+      AppendNumberTo(&result, inputs[i]->fd.GetNumber());
+    }
+    return result;
+  }
 };
 
 TEST_F(VersionStorageInfoTest, MaxBytesForLevelStatic) {
@@ -258,6 +288,40 @@ TEST_F(VersionStorageInfoTest, EstimateLiveDataSize2) {
   Add(3, 5U, "7", "8", 1U);
   ASSERT_EQ(4U, vstorage_.EstimateLiveDataSize());
 }
+
+TEST_F(VersionStorageInfoTest, GetOverlappingInputs) {
+  // Two files that overlap at the range deletion tombstone sentinel.
+  Add(1, 1U, {"a", 0, kTypeValue}, {"b", kMaxSequenceNumber, kTypeRangeDeletion}, 1);
+  Add(1, 2U, {"b", 0, kTypeValue}, {"c", 0, kTypeValue}, 1);
+  // Two files that overlap at the same user key.
+  Add(1, 3U, {"d", 0, kTypeValue}, {"e", kMaxSequenceNumber, kTypeValue}, 1);
+  Add(1, 4U, {"e", 0, kTypeValue}, {"f", 0, kTypeValue}, 1);
+  // Two files that do not overlap.
+  Add(1, 5U, {"g", 0, kTypeValue}, {"h", 0, kTypeValue}, 1);
+  Add(1, 6U, {"i", 0, kTypeValue}, {"j", 0, kTypeValue}, 1);
+  vstorage_.UpdateNumNonEmptyLevels();
+  vstorage_.GenerateLevelFilesBrief();
+
+  ASSERT_EQ("1,2", GetOverlappingFiles(
+      1, {"a", 0, kTypeValue}, {"b", 0, kTypeValue}));
+  ASSERT_EQ("1", GetOverlappingFiles(
+      1, {"a", 0, kTypeValue}, {"b", kMaxSequenceNumber, kTypeRangeDeletion}));
+  ASSERT_EQ("2", GetOverlappingFiles(
+      1, {"b", kMaxSequenceNumber, kTypeValue}, {"c", 0, kTypeValue}));
+  ASSERT_EQ("3,4", GetOverlappingFiles(
+      1, {"d", 0, kTypeValue}, {"e", 0, kTypeValue}));
+  ASSERT_EQ("3", GetOverlappingFiles(
+      1, {"d", 0, kTypeValue}, {"e", kMaxSequenceNumber, kTypeRangeDeletion}));
+  ASSERT_EQ("3,4", GetOverlappingFiles(
+      1, {"e", kMaxSequenceNumber, kTypeValue}, {"f", 0, kTypeValue}));
+  ASSERT_EQ("3,4", GetOverlappingFiles(
+      1, {"e", 0, kTypeValue}, {"f", 0, kTypeValue}));
+  ASSERT_EQ("5", GetOverlappingFiles(
+      1, {"g", 0, kTypeValue}, {"h", 0, kTypeValue}));
+  ASSERT_EQ("6", GetOverlappingFiles(
+      1, {"i", 0, kTypeValue}, {"j", 0, kTypeValue}));
+}
+
 
 class FindLevelFileTest : public testing::Test {
  public:

--- a/include/rocksdb/table_properties.h
+++ b/include/rocksdb/table_properties.h
@@ -38,6 +38,7 @@ struct TablePropertiesNames {
   static const std::string kRawValueSize;
   static const std::string kNumDataBlocks;
   static const std::string kNumEntries;
+  static const std::string kNumRangeDeletions;
   static const std::string kFormatVersion;
   static const std::string kFixedKeyLen;
   static const std::string kFilterPolicy;
@@ -144,6 +145,8 @@ struct TableProperties {
   uint64_t num_data_blocks = 0;
   // the number of entries in this table
   uint64_t num_entries = 0;
+  // the number of range deletions in this table
+  uint64_t num_range_deletions = 0;
   // format version, reserved for backward compatibility
   uint64_t format_version = 0;
   // If 0, key is variable length. Otherwise number of bytes for each key.

--- a/table/block_based_table_builder.cc
+++ b/table/block_based_table_builder.cc
@@ -429,9 +429,8 @@ void BlockBasedTableBuilder::Add(const Slice& key, const Slice& value) {
                                       r->ioptions.info_log);
 
   } else if (value_type == kTypeRangeDeletion) {
-    // TODO(wanning&andrewkr) add num_tomestone to table properties
     r->range_del_block.Add(key, value);
-    ++r->props.num_entries;
+    ++r->props.num_range_deletions;
     r->props.raw_key_size += key.size();
     r->props.raw_value_size += value.size();
     NotifyCollectTableCollectorsOnAdd(key, value, r->offset,

--- a/table/cuckoo_table_reader.cc
+++ b/table/cuckoo_table_reader.cc
@@ -377,7 +377,11 @@ extern InternalIterator* NewErrorInternalIterator(const Status& status,
                                                   Arena* arena);
 
 InternalIterator* CuckooTableReader::NewIterator(
-    const ReadOptions& /*read_options*/, Arena* arena, bool /*skip_filters*/) {
+    const ReadOptions& /* read_options */,
+    RangeDelAggregator* /* range_del_agg */,
+    const FileMetaData* /* file_meta */,
+    Arena* arena,
+    bool /* skip_filters */) {
   if (!status().ok()) {
     return NewErrorInternalIterator(
         Status::Corruption("CuckooTableReader status is not okay."), arena);

--- a/table/cuckoo_table_reader.h
+++ b/table/cuckoo_table_reader.h
@@ -45,9 +45,11 @@ class CuckooTableReader: public TableReader {
   Status Get(const ReadOptions& read_options, const Slice& key,
              GetContext* get_context, bool skip_filters = false) override;
 
-  InternalIterator* NewIterator(
-      const ReadOptions&, Arena* arena = nullptr,
-      bool skip_filters = false) override;
+  InternalIterator* NewIterator(const ReadOptions&,
+                                RangeDelAggregator* range_del_agg = nullptr,
+                                const FileMetaData* file_meta = nullptr,
+                                Arena* arena = nullptr,
+                                bool skip_filters = false) override;
   void Prepare(const Slice& target) override;
 
   // Report an approximation of how much memory has been used.

--- a/table/cuckoo_table_reader_test.cc
+++ b/table/cuckoo_table_reader_test.cc
@@ -149,7 +149,8 @@ class CuckooReaderTest : public testing::Test {
     CuckooTableReader reader(ioptions, std::move(file_reader), file_size, ucomp,
                              GetSliceHash);
     ASSERT_OK(reader.status());
-    InternalIterator* it = reader.NewIterator(ReadOptions(), nullptr);
+    InternalIterator* it =
+        reader.NewIterator(ReadOptions(), nullptr, nullptr, nullptr);
     ASSERT_OK(it->status());
     ASSERT_TRUE(!it->Valid());
     it->SeekToFirst();
@@ -188,7 +189,7 @@ class CuckooReaderTest : public testing::Test {
     delete it;
 
     Arena arena;
-    it = reader.NewIterator(ReadOptions(), &arena);
+    it = reader.NewIterator(ReadOptions(), nullptr, nullptr, &arena);
     ASSERT_OK(it->status());
     ASSERT_TRUE(!it->Valid());
     it->Seek(keys[num_items/2]);

--- a/table/meta_blocks.cc
+++ b/table/meta_blocks.cc
@@ -72,6 +72,7 @@ void PropertyBlockBuilder::AddTableProperty(const TableProperties& props) {
     Add(TablePropertiesNames::kTopLevelIndexSize, props.top_level_index_size);
   }
   Add(TablePropertiesNames::kNumEntries, props.num_entries);
+  Add(TablePropertiesNames::kNumRangeDeletions, props.num_range_deletions);
   Add(TablePropertiesNames::kNumDataBlocks, props.num_data_blocks);
   Add(TablePropertiesNames::kFilterSize, props.filter_size);
   Add(TablePropertiesNames::kFormatVersion, props.format_version);
@@ -210,6 +211,8 @@ Status ReadProperties(const Slice& handle_value, RandomAccessFileReader* file,
       {TablePropertiesNames::kNumDataBlocks,
        &new_table_properties->num_data_blocks},
       {TablePropertiesNames::kNumEntries, &new_table_properties->num_entries},
+      {TablePropertiesNames::kNumRangeDeletions,
+       &new_table_properties->num_range_deletions},
       {TablePropertiesNames::kFormatVersion,
        &new_table_properties->format_version},
       {TablePropertiesNames::kFixedKeyLen,

--- a/table/mock_table.cc
+++ b/table/mock_table.cc
@@ -26,9 +26,11 @@ stl_wrappers::KVMap MakeMockFile(
   return stl_wrappers::KVMap(l, stl_wrappers::LessOfComparator(&icmp_));
 }
 
-InternalIterator* MockTableReader::NewIterator(const ReadOptions&,
-                                               Arena* /*arena*/,
-                                               bool /*skip_filters*/) {
+InternalIterator* MockTableReader::NewIterator(
+    const ReadOptions&,
+    RangeDelAggregator* /* range_del_agg */,
+    const FileMetaData* /* file_meta */,
+    Arena* /*arena*/, bool /*skip_filters*/) {
   return new MockTableIterator(table_);
 }
 

--- a/table/mock_table.h
+++ b/table/mock_table.h
@@ -39,7 +39,9 @@ class MockTableReader : public TableReader {
   explicit MockTableReader(const stl_wrappers::KVMap& table) : table_(table) {}
 
   InternalIterator* NewIterator(const ReadOptions&,
-                                Arena* arena,
+                                RangeDelAggregator* range_del_agg = nullptr,
+                                const FileMetaData* file_meta = nullptr,
+                                Arena* arena = nullptr,
                                 bool skip_filters = false) override;
 
   Status Get(const ReadOptions&, const Slice& key, GetContext* get_context,

--- a/table/plain_table_reader.cc
+++ b/table/plain_table_reader.cc
@@ -189,9 +189,11 @@ Status PlainTableReader::Open(const ImmutableCFOptions& ioptions,
 void PlainTableReader::SetupForCompaction() {
 }
 
-InternalIterator* PlainTableReader::NewIterator(const ReadOptions& options,
-                                                Arena* arena,
-                                                bool /*skip_filters*/) {
+InternalIterator* PlainTableReader::NewIterator(
+    const ReadOptions& options,
+    RangeDelAggregator* /* range_del_agg */,
+    const FileMetaData* /* file_meta */,
+    Arena* arena, bool /*skip_filters*/) {
   bool use_prefix_seek = !IsTotalOrderMode() && !options.total_order_seek;
   if (arena == nullptr) {
     return new PlainTableIterator(this, use_prefix_seek);

--- a/table/plain_table_reader.h
+++ b/table/plain_table_reader.h
@@ -79,6 +79,8 @@ class PlainTableReader: public TableReader {
                      bool full_scan_mode);
 
   InternalIterator* NewIterator(const ReadOptions&,
+                                RangeDelAggregator* range_del_agg = nullptr,
+                                const FileMetaData* file_meta = nullptr,
                                 Arena* arena = nullptr,
                                 bool skip_filters = false) override;
 

--- a/table/table_properties.cc
+++ b/table/table_properties.cc
@@ -78,6 +78,8 @@ std::string TableProperties::ToString(
   AppendProperty(result, "# data blocks", num_data_blocks, prop_delim,
                  kv_delim);
   AppendProperty(result, "# entries", num_entries, prop_delim, kv_delim);
+  AppendProperty(result, "# range deletions", num_range_deletions, prop_delim,
+                 kv_delim);
 
   AppendProperty(result, "raw key size", raw_key_size, prop_delim, kv_delim);
   AppendProperty(result, "raw average key size",
@@ -155,6 +157,7 @@ void TableProperties::Add(const TableProperties& tp) {
   raw_value_size += tp.raw_value_size;
   num_data_blocks += tp.num_data_blocks;
   num_entries += tp.num_entries;
+  num_range_deletions += tp.num_range_deletions;
 }
 
 const std::string TablePropertiesNames::kDataSize  =
@@ -175,6 +178,8 @@ const std::string TablePropertiesNames::kNumDataBlocks =
     "rocksdb.num.data.blocks";
 const std::string TablePropertiesNames::kNumEntries =
     "rocksdb.num.entries";
+const std::string TablePropertiesNames::kNumRangeDeletions =
+    "rocksdb.num.range-deletions";
 const std::string TablePropertiesNames::kFilterPolicy =
     "rocksdb.filter.policy";
 const std::string TablePropertiesNames::kFormatVersion =

--- a/table/table_reader.h
+++ b/table/table_reader.h
@@ -21,6 +21,8 @@ struct ReadOptions;
 struct TableProperties;
 class GetContext;
 class InternalIterator;
+struct FileMetaData;
+class RangeDelAggregator;
 
 // A Table is a sorted map from strings to strings.  Tables are
 // immutable and persistent.  A Table may be safely accessed from
@@ -39,6 +41,8 @@ class TableReader {
   // skip_filters: disables checking the bloom filters even if they exist. This
   //               option is effective only for block-based table format.
   virtual InternalIterator* NewIterator(const ReadOptions&,
+                                        RangeDelAggregator* range_del_agg = nullptr,
+                                        const FileMetaData* file_meta = nullptr,
                                         Arena* arena = nullptr,
                                         bool skip_filters = false) = 0;
 


### PR DESCRIPTION
Backport the various range tombstone PRs in the same order that we expect them to land upstream. Note that the target for this PR is `crl-release-5.13.new`, not `crl-release-5.13`. After this merges, I'll replace `crl-release-5.13` with `crl-release-5.13.new`. The last 7 commits were from #2, #3 and #4 with minor updates to `range_del_aggregator.cc` to adapt to the new code structure. The first commit is https://github.com/facebook/rocksdb/pull/3800.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/rocksdb/8)
<!-- Reviewable:end -->
