### PR TITLE
Stop-gap for unimplemented UncollapsedRangeDelMap::ShouldDeleteRange

### DIFF
--- a/db/range_del_aggregator.cc
+++ b/db/range_del_aggregator.cc
@@ -67,10 +67,13 @@ class UncollapsedRangeDelMap : public RangeDelMap {
 
   bool ShouldDeleteRange(const Slice& start, const Slice& end,
                          SequenceNumber seqno) {
-    // Unimplemented because the only client of this method, iteration, uses
-    // collapsed maps.
-    fprintf(stderr, "UncollapsedRangeDelMap::ShouldDeleteRange unimplemented");
-    abort();
+    // Unimplemented, though the lack of implementation only affects
+    // performance (not correctness) for sstable ingestion. Normal read
+    // operations use a CollapsedRangeDelMap.
+    //
+    // TODO(peter): This is called from
+    // Version::OverlapWithLevelIterator. That method needs to be tested in
+    // the presence of range tombstones.
     return false;
   }
 


### PR DESCRIPTION
I'll work on either a test or a real implementation next week.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/rocksdb/9)
<!-- Reviewable:end -->
