### PR TITLE
Properly handle range tombstones at the same seqnum as a key

### DIFF
--- a/db/range_del_aggregator_test.cc
+++ b/db/range_del_aggregator_test.cc
@@ -375,6 +375,10 @@ TEST_F(RangeDelAggregatorTest, GetTombstone) {
       {"b", "d", 10});
   VerifyGetTombstone(
       {{"b", "d", 10}},
+      {"b", 10},
+      {"b", "d", 0});
+  VerifyGetTombstone(
+      {{"b", "d", 10}},
       {"b", 20},
       {"b", "d", 0});
   VerifyGetTombstone(
@@ -395,12 +399,16 @@ TEST_F(RangeDelAggregatorTest, GetTombstone) {
       {"a", "c", 10});
   VerifyGetTombstone(
       {{"a", "c", 10}, {"e", "h", 20}},
-      {"e", 9},
+      {"b", 10},
+      {"a", "c", 0});
+  VerifyGetTombstone(
+      {{"a", "c", 10}, {"e", "h", 20}},
+      {"e", 19},
       {"e", "h", 20});
   VerifyGetTombstone(
       {{"a", "c", 10}, {"e", "h", 20}},
-      {"e", 9},
-      {"e", "h", 20});
+      {"e", 20},
+      {"e", "h", 0});
 }
 
 TEST_F(RangeDelAggregatorTest, TruncateTombstones) {


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/rocksdb/10)
<!-- Reviewable:end -->
