### PR TITLE
Fix skipping of range deleted keys in BlockBasedTableIterator

### DIFF
--- a/db/db_range_del_test.cc
+++ b/db/db_range_del_test.cc
@@ -316,8 +316,6 @@ TEST_F(DBRangeDelTest, CompactionRemovesCoveredKeys) {
   db_->CompactRange(CompactRangeOptions(), nullptr, nullptr);
   ASSERT_EQ(0, NumTableFilesAtLevel(0));
   ASSERT_GT(NumTableFilesAtLevel(1), 0);
-  ASSERT_EQ((kNumFiles - 1) * kNumPerFile / 2,
-            TestGetTickerCount(opts, COMPACTION_KEY_DROP_RANGE_DEL));
 
   for (int i = 0; i < kNumFiles; ++i) {
     for (int j = 0; j < kNumPerFile; ++j) {
@@ -813,23 +811,120 @@ TEST_F(DBRangeDelTest, IteratorIgnoresRangeDeletions) {
   db_->ReleaseSnapshot(snapshot);
 }
 
-TEST_F(DBRangeDelTest, IteratorCoveredSst) {
-  // TODO(peter): generate multiple sstables with some being covered
-  // by tombstones and some that aren't.
-  db_->Put(WriteOptions(), "key", "val");
-  ASSERT_OK(db_->Flush(FlushOptions()));
-  db_->CompactRange(CompactRangeOptions(), nullptr, nullptr);
-  ASSERT_OK(db_->DeleteRange(WriteOptions(), db_->DefaultColumnFamily(), "a", "z"));
+TEST_F(DBRangeDelTest, IteratorRangeTombstoneOverlapsSstable) {
+  struct TestCase {
+    const Comparator* comparator;
+    std::vector<std::string> table_keys;
+    std::vector<Range> range_del;
+    std::vector<std::string> expected_keys;
+  };
 
-  ReadOptions read_opts;
-  auto* iter = db_->NewIterator(read_opts);
+  std::vector<TestCase> test_cases = {
+    // Range tombstone covers the sstable.
+    {
+      BytewiseComparator(),
+      { "a", "b", "c" },
+      { { "a", "d" } },
+      { },
+    },
+    // Range tombstone overlaps the start of the sstable.
+    {
+      BytewiseComparator(),
+      { "a", "b", "c" },
+      { { "", "b" } },
+      { "b", "c" },
+    },
+    // Empty range tombstone start key and empty key.
+    {
+      BytewiseComparator(),
+      { "", "b", "c" },
+      { { "", "b" } },
+      { "b", "c" },
+    },
+    // Range tombstone overlaps the end of the sstable.
+    {
+      BytewiseComparator(),
+      { "a", "b", "c" },
+      { { "c", "d" } },
+      { "a", "b" },
+    },
+    // Range tombstones overlap both the start and the end of the
+    // sstable.
+    {
+      BytewiseComparator(),
+      { "a", "b", "c" },
+      { { "", "b" }, { "c", "d" } },
+      { "b" },
+    },
+    // Range tombstone overlaps the middle of the sstable.
+    {
+      BytewiseComparator(),
+      { "a", "b", "c" },
+      { { "b", "c" } },
+      { "a", "c" },
+    },
+    // Multiple range tombstones overlapping the sstable.
+    {
+      BytewiseComparator(),
+      { "a", "b", "c", "d", "e" },
+      { { "b", "c" }, { "d", "e" } },
+      { "a", "c", "e" },
+    },
+    // Reverse comparator with empty range tombstone end key.
+    {
+      ReverseBytewiseComparator(),
+      { "b", "a", "" },
+      { { "a", "" }, { "b", "a" } },
+      { "" },
+    },
+  };
+  for (auto tc : test_cases) {
+    Options options = CurrentOptions();
+    options.comparator = tc.comparator;
+    DestroyAndReopen(options);
 
-  int count = 0;
-  for (iter->SeekToFirst(); iter->Valid(); iter->Next()) {
-    ++count;
+    for (auto key : tc.table_keys) {
+      db_->Put(WriteOptions(), key, "");
+    }
+
+    ASSERT_OK(db_->Flush(FlushOptions()));
+    db_->CompactRange(CompactRangeOptions(), nullptr, nullptr);
+
+    for (auto d : tc.range_del) {
+      db_->DeleteRange(WriteOptions(), db_->DefaultColumnFamily(), d.start, d.limit);
+    }
+
+    {
+      unique_ptr<Iterator> iter(db_->NewIterator(ReadOptions()));
+      std::vector<std::string> keys;
+      for (iter->SeekToFirst(); iter->Valid(); iter->Next()) {
+        keys.emplace_back(iter->key().ToString());
+      }
+      ASSERT_EQ(tc.expected_keys, keys);
+    }
+
+    {
+      unique_ptr<Iterator> iter(db_->NewIterator(ReadOptions()));
+      std::vector<std::string> keys;
+      for (iter->SeekToLast(); iter->Valid(); iter->Prev()) {
+        keys.emplace_back(iter->key().ToString());
+      }
+      std::reverse(keys.begin(), keys.end());
+      ASSERT_EQ(tc.expected_keys, keys);
+    }
+
+    {
+      unique_ptr<Iterator> iter(db_->NewIterator(ReadOptions()));
+      for (auto key : tc.expected_keys) {
+        iter->Seek(key);
+        ASSERT_TRUE(iter->Valid());
+        ASSERT_EQ(key, iter->key());
+        iter->SeekForPrev(key);
+        ASSERT_TRUE(iter->Valid());
+        ASSERT_EQ(key, iter->key());
+      }
+    }
   }
-  ASSERT_EQ(0, count);
-  delete iter;
 }
 
 #ifndef ROCKSDB_UBSAN_RUN

--- a/db/forward_iterator.h
+++ b/db/forward_iterator.h
@@ -14,6 +14,7 @@
 #include "rocksdb/iterator.h"
 #include "rocksdb/options.h"
 #include "db/dbformat.h"
+#include "db/range_del_aggregator.h"
 #include "table/internal_iterator.h"
 #include "util/arena.h"
 
@@ -121,6 +122,7 @@ class ForwardIterator : public InternalIterator {
   const SliceTransform* const prefix_extractor_;
   const Comparator* user_comparator_;
   MinIterHeap immutable_min_heap_;
+  RangeDelAggregator range_del_agg_;
 
   SuperVersion* sv_;
   InternalIterator* mutable_iter_;

--- a/db/range_del_aggregator.cc
+++ b/db/range_del_aggregator.cc
@@ -77,12 +77,14 @@ class UncollapsedRangeDelMap : public RangeDelMap {
     return false;
   }
 
-  RangeTombstone GetTombstone(const Slice& user_key, SequenceNumber seqno) {
-    // Unimplemented because the only client of this method, iteration, uses
-    // collapsed maps.
-    fprintf(stderr, "UncollapsedRangeDelMap::GetTombstone unimplemented");
-    abort();
-    return RangeTombstone(Slice(), Slice(), 0);
+  std::pair<RangePtr,SequenceNumber> GetTombstone(
+      const Slice& user_key, SequenceNumber seqno) {
+    // Unimplemented, though the lack of implementation only affects
+    // performance (not correctness) for sstable ingestion. Normal
+    // read operations use a CollapsedRangeDelMap.
+    (void)user_key;
+    (void)seqno;
+    return std::make_pair(RangePtr(), 0);
   }
 
   bool IsRangeOverlapped(const Slice& start, const Slice& end) {
@@ -266,11 +268,12 @@ class CollapsedRangeDelMap : public RangeDelMap {
     }
     --iter;
     if (ucmp_->Compare(parsed_start.user_key, iter->first) < 0) {
+      assert(false);
       return false;
     }
-    // Loop looking for a tombstone that is older than the range
-    // sequence number, or we determine that our range is completely
-    // covered by newer tombstones.
+    // Loop looking for a tombstone that is older than the range sequence
+    // number, or we determine that our range is completely covered by newer
+    // tombstones.
     for (; iter != rep_.end(); ++iter) {
       if (ucmp_->Compare(parsed_end.user_key, iter->first) < 0) {
         return true;
@@ -283,22 +286,23 @@ class CollapsedRangeDelMap : public RangeDelMap {
     return false;
   }
 
-  RangeTombstone GetTombstone(const Slice& user_key, SequenceNumber seqno) {
+  std::pair<RangePtr,SequenceNumber> GetTombstone(
+      const Slice& user_key, SequenceNumber seqno) {
     auto iter = rep_.upper_bound(user_key);
     if (iter == rep_.begin()) {
       // before start of deletion intervals
-      return RangeTombstone(Slice(), iter->first, 0);
+      return std::make_pair(RangePtr(nullptr, &iter->first), 0);
     }
     auto prev = iter;
     --prev;
     if (iter == rep_.end()) {
       // after end of deletion intervals
-      return RangeTombstone(prev->first, Slice(), 0);
+      return std::make_pair(RangePtr(&prev->first, nullptr), 0);
     }
     // Note that a range tombstone does not cover a key at the same sequence
     // number. This can occur in an sstable that has been ingested where all
     // of the entries have the same sequence number.
-    return RangeTombstone(prev->first, iter->first,
+    return std::make_pair(RangePtr(&prev->first, &iter->first),
                           prev->second > seqno ? prev->second : 0);
   }
 
@@ -419,7 +423,12 @@ class CollapsedRangeDelMap : public RangeDelMap {
     }
   }
 
-  size_t Size() const { return rep_.size() - 1; }
+  size_t Size() const {
+    if (rep_.empty()) {
+      return 0;
+    }
+    return rep_.size() - 1;
+  }
 
   void InvalidatePosition() { iter_ = rep_.end(); }
 
@@ -499,14 +508,14 @@ bool RangeDelAggregator::ShouldDeleteRange(
   return tombstone_map.ShouldDeleteRange(start, end, seqno);
 }
 
-RangeTombstone RangeDelAggregator::GetTombstone(const Slice& user_key,
-                                                SequenceNumber seqno) {
+std::pair<RangePtr,SequenceNumber> RangeDelAggregator::GetTombstone(
+    const Slice& user_key, SequenceNumber seqno) {
   if (rep_ == nullptr) {
-    return RangeTombstone(Slice(), Slice(), 0);
+    return std::make_pair(RangePtr(), 0);
   }
   auto& tombstone_map = GetRangeDelMap(seqno);
   if (tombstone_map.IsEmpty()) {
-    return RangeTombstone(Slice(), Slice(), 0);
+    return std::make_pair(RangePtr(), 0);
   }
   return tombstone_map.GetTombstone(user_key, seqno);
 }

--- a/db/range_del_aggregator.h
+++ b/db/range_del_aggregator.h
@@ -63,8 +63,8 @@ class RangeDelMap {
                             RangeDelPositioningMode mode) = 0;
   virtual bool ShouldDeleteRange(const Slice& start, const Slice& end,
                                  SequenceNumber seqno) = 0;
-  virtual RangeTombstone GetTombstone(const Slice& user_key,
-                                      SequenceNumber seqno) = 0;
+  virtual std::pair<RangePtr,SequenceNumber> GetTombstone(
+      const Slice& user_key, SequenceNumber seqno) = 0;
   virtual bool IsRangeOverlapped(const Slice& start, const Slice& end) = 0;
   virtual void InvalidatePosition() = 0;
 
@@ -141,9 +141,9 @@ class RangeDelAggregator {
   // Get the range tombstone at the specified user_key and sequence number. A
   // valid tombstone is always returned, though it may cover an empty range of
   // keys or the sequence number may be 0 to indicate that no tombstone covers
-  // the specified range of keys.
-  RangeTombstone GetTombstone(const Slice& user_key,
-                              SequenceNumber seqno);
+  // the specified key.
+  std::pair<RangePtr,SequenceNumber> GetTombstone(const Slice& user_key,
+                                                  SequenceNumber seqno);
 
   // Checks whether range deletions cover any keys between `start` and `end`,
   // inclusive.

--- a/db/range_del_aggregator_test.cc
+++ b/db/range_del_aggregator_test.cc
@@ -162,6 +162,7 @@ void VerifyGetTombstone(const std::vector<RangeTombstone>& range_dels,
                         const ExpectedPoint& expected_point,
                         const RangeTombstone& expected_tombstone) {
   RangeDelAggregator range_del_agg(icmp, {} /* snapshots */, true);
+  ASSERT_TRUE(range_del_agg.IsEmpty());
   std::vector<std::string> keys, values;
   for (const auto& range_del : range_dels) {
     auto key_and_value = range_del.Serialize();
@@ -173,9 +174,11 @@ void VerifyGetTombstone(const std::vector<RangeTombstone>& range_dels,
   range_del_agg.AddTombstones(std::move(range_del_iter));
 
   auto tombstone = range_del_agg.GetTombstone(expected_point.begin, expected_point.seq);
-  ASSERT_EQ(expected_tombstone.start_key_.ToString(), tombstone.start_key_.ToString());
-  ASSERT_EQ(expected_tombstone.end_key_.ToString(), tombstone.end_key_.ToString());
-  ASSERT_EQ(expected_tombstone.seq_, tombstone.seq_);
+  auto start = tombstone.first.start ? tombstone.first.start->ToString() : "";
+  auto end = tombstone.first.limit ? tombstone.first.limit->ToString() : "";
+  ASSERT_EQ(expected_tombstone.start_key_.ToString(), start);
+  ASSERT_EQ(expected_tombstone.end_key_.ToString(), end);
+  ASSERT_EQ(expected_tombstone.seq_, tombstone.second);
 }
 
 }  // anonymous namespace
@@ -422,6 +425,25 @@ TEST_F(RangeDelAggregatorTest, TruncateTombstones) {
        {"e", 10, true}}, // truncated
       {{"b", "c", 10}, {"d", "e", 10}},
       &smallest, &largest);
+}
+
+TEST_F(RangeDelAggregatorTest, IsEmpty) {
+  const std::vector<SequenceNumber> snapshots;
+  RangeDelAggregator range_del_agg1(
+      icmp, snapshots, false /* collapse_deletions */);
+  ASSERT_TRUE(range_del_agg1.IsEmpty());
+
+  RangeDelAggregator range_del_agg2(
+      icmp, snapshots, true /* collapse_deletions */);
+  ASSERT_TRUE(range_del_agg2.IsEmpty());
+
+  RangeDelAggregator range_del_agg3(
+      icmp, kMaxSequenceNumber, false /* collapse_deletions */);
+  ASSERT_TRUE(range_del_agg3.IsEmpty());
+
+  RangeDelAggregator range_del_agg4(
+      icmp, kMaxSequenceNumber, true /* collapse_deletions */);
+  ASSERT_TRUE(range_del_agg4.IsEmpty());
 }
 
 }  // namespace rocksdb

--- a/db/table_cache.cc
+++ b/db/table_cache.cc
@@ -231,7 +231,7 @@ InternalIterator* TableCache::NewIterator(
       result = NewEmptyInternalIterator(arena);
     } else {
       result = table_reader->NewIterator(
-          options, range_del_agg, nullptr /* file_meta */,
+          options, range_del_agg, &file_meta,
           arena, skip_filters);
     }
     if (create_new_table_reader) {

--- a/table/block_based_table_reader.h
+++ b/table/block_based_table_reader.h
@@ -508,7 +508,9 @@ class BlockBasedTableIterator : public InternalIterator {
         icomp_(icomp),
         range_del_agg_(range_del_agg),
         file_meta_(file_meta),
-        range_tombstone_(Slice(), Slice(), 0),
+        range_tombstone_start_(nullptr),
+        range_tombstone_end_(nullptr),
+        range_tombstone_seq_(0),
         index_iter_(index_iter),
         pinned_iters_mgr_(nullptr),
         block_iter_points_to_real_block_(false),
@@ -604,25 +606,8 @@ private:
   // the current file, allowing us to skip over a swath of deleted keys.
   void InitRangeTombstone(const Slice& target);
 
-  std::string tombstone_internal_start_key() const {
-    std::string internal_key;
-    AppendInternalKey(&internal_key, {
-        range_tombstone_.start_key_, range_tombstone_.seq_, kTypeValue});
-    return internal_key;
-  }
-
-  std::string tombstone_internal_end_key() const {
-    std::string internal_key;
-    // We specify kMaxSequenceNumber instead of the tombstone's
-    // sequence number because internal keys are ordered by descending
-    // sequence number. Using kMaxSequenceNumber ensures we'll seek to
-    // a version of the key that is more recent than the
-    // tombstone. Note that the tombstone end-key is exclusive, so the
-    // tombstone doesn't apply to the end-key in any case.
-    AppendInternalKey(&internal_key, {
-        range_tombstone_.end_key_, kMaxSequenceNumber, kTypeValue});
-    return internal_key;
-  }
+  std::string tombstone_internal_start_key() const;
+  std::string tombstone_internal_end_key() const;
 
   Slice user_key() const {
     assert(Valid());
@@ -638,9 +623,11 @@ private:
   // The range tombstone that covers the current key. Note that this is a
   // cooked value, not the raw tombstone as retrieved from
   // RangeDelAggregator::GetTombstone(). In particular, the start and end keys
-  // will be cleared to indicate the tombstone extends past the beginning or
+  // will be nullptr to indicate the tombstone extends past the beginning or
   // end of the sstable.
-  RangeTombstone range_tombstone_;
+  const Slice* range_tombstone_start_;
+  const Slice* range_tombstone_end_;
+  SequenceNumber range_tombstone_seq_;
   InternalIterator* index_iter_;
   PinnedIteratorsManager* pinned_iters_mgr_;
   BlockIter data_block_iter_;


### PR DESCRIPTION
TableCache::NewIterator was failing to pass the file metadata to
BlockBasedTableReader::NewIterator, so all of the fancy code in
BlockBasedTableIterator to skip ranges of deleted keys was not being
used.

Changed BlockBasedTableIterator to represent range tombstone endpoints
that extend to infinity using a nullptr rather than an empty key. An
empty key is a valid key and doing anything with a key other than using
it for comparison using the user comparator is invalid.

A tweak to the existing `BenchmarkRocksDBDeleteRangeIterate` shows the benefit from this change:

```
name                                                       old time/op  new time/op  delta
RocksDBDeleteRangeIterate/entries=10/deleted=9-8           6.11µs ± 2%  5.45µs ± 3%  -10.80%  (p=0.000 n=10+10)
RocksDBDeleteRangeIterate/entries=1000/deleted=999-8        132µs ± 3%     6µs ± 4%  -95.35%  (p=0.000 n=9+10)
RocksDBDeleteRangeIterate/entries=100000/deleted=99999-8   12.4ms ± 1%   0.0ms ± 3%  -99.95%  (p=0.000 n=9+9)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/rocksdb/11)
<!-- Reviewable:end -->
