### PR TITLE
Adjust wording of PartialRangeTombstone description

### DIFF
--- a/db/dbformat.h
+++ b/db/dbformat.h
@@ -618,9 +618,9 @@ struct RangeTombstone {
 };
 
 // A PartialRangeTombstone represents a range tombstone whose start and end keys
-// may not exist. It is notably returned by RangeDelAggregator::GetTombstone,
+// may be infinite. It is notably returned by RangeDelAggregator::GetTombstone,
 // where a PartialRangeTombstone with a nullptr start key represents a synthetic
-// tombstone before the first real tombstone, and a PartialRangeTombstone with a
+// tombstone before the first real tombstone and a PartialRangeTombstone with a
 // nullptr end key represents a synthetic tombstone after the last real range
 // tombstone. Unlike RangeTombstones, PartialRangeTombstones are never
 // serialized and stored to disk. They exist only in memory.


### PR DESCRIPTION
Adjust the wording of the PartialRangeTombstone description to be more
precise about the fact that a nullptr start or end key represents an
infinite bound, not a non-existent bound.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/rocksdb/13)
<!-- Reviewable:end -->
