### PR TITLE
Fix bug when seeking backward against an out-of-bound iterator (#4187)

### DIFF
--- a/db/db_iterator_test.cc
+++ b/db/db_iterator_test.cc
@@ -2310,6 +2310,30 @@ TEST_P(DBIteratorTest, SeekAfterHittingManyInternalKeys) {
   ASSERT_EQ(iter2->value().ToString(), "val_6");
 }
 
+TEST_P(DBIteratorTest, SeekBackwardAfterOutOfUpperBound) {
+  Put("a", "");
+  Put("b", "");
+  Flush();
+
+  ReadOptions ropt;
+  Slice ub = "b";
+  ropt.iterate_upper_bound = &ub;
+
+  std::unique_ptr<Iterator> it(dbfull()->NewIterator(ropt));
+  it->SeekForPrev("a");
+  ASSERT_TRUE(it->Valid());
+  ASSERT_OK(it->status());
+  ASSERT_EQ("a", it->key().ToString());
+  it->Next();
+  ASSERT_FALSE(it->Valid());
+  ASSERT_OK(it->status());
+  it->SeekForPrev("a");
+  ASSERT_OK(it->status());
+
+  ASSERT_TRUE(it->Valid());
+  ASSERT_EQ("a", it->key().ToString());
+}
+
 INSTANTIATE_TEST_CASE_P(DBIteratorTestInstance, DBIteratorTest,
                         testing::Values(true, false));
 

--- a/table/block_based_table_reader.cc
+++ b/table/block_based_table_reader.cc
@@ -1780,6 +1780,7 @@ bool BlockBasedTable::PrefixMayMatch(const Slice& internal_key) {
 }
 
 void BlockBasedTableIterator::Seek(const Slice& const_target) {
+  is_out_of_bound_ = false;
   Slice target(const_target);
   if (!CheckPrefixMayMatch(target)) {
     ResetDataIter();
@@ -1813,6 +1814,7 @@ void BlockBasedTableIterator::Seek(const Slice& const_target) {
 }
 
 void BlockBasedTableIterator::SeekForPrev(const Slice& const_target) {
+  is_out_of_bound_ = false;
   Slice target(const_target);
   if (!CheckPrefixMayMatch(target)) {
     ResetDataIter();
@@ -1863,6 +1865,7 @@ void BlockBasedTableIterator::SeekForPrev(const Slice& const_target) {
 }
 
 void BlockBasedTableIterator::SeekToFirst() {
+  is_out_of_bound_ = false;
   SavePrevIndexValue();
   index_iter_->SeekToFirst();
   if (!index_iter_->Valid()) {
@@ -1878,6 +1881,7 @@ void BlockBasedTableIterator::SeekToFirst() {
 }
 
 void BlockBasedTableIterator::SeekToLast() {
+  is_out_of_bound_ = false;
   SavePrevIndexValue();
   index_iter_->SeekToLast();
   if (!index_iter_->Valid()) {
@@ -1949,7 +1953,7 @@ void BlockBasedTableIterator::FindKeyForward() {
   // a call to Seek, SeekToFirst or Next) and we're looking for the next valid
   // key.
 
-  is_out_of_bound_ = false;
+  assert(!is_out_of_bound_);
   for (;;) {
     // TODO the while loop inherits from two-level-iterator. We don't know
     // whether a block can be empty so it can be replaced by an "if".
@@ -2046,6 +2050,7 @@ void BlockBasedTableIterator::FindKeyBackward() {
   // (via a call to SeekForPrev, SeekToLast or Prev) and we're looking for the
   // next valid key.
 
+  assert(!is_out_of_bound_);
   for (;;) {
     while (!data_block_iter_.Valid()) {
       if (!data_block_iter_.status().ok()) {


### PR DESCRIPTION
Summary:
92ee3350e0ae02c0973af0fbd40fb67b0b958128 introduces an out-of-bound check in BlockBasedTableIterator::Valid(). However, this flag is not reset when re-seeking in backward direction. This caused the iterator to be invalide by mistake. Fix it by always resetting the out-of-bound flag in every seek.
Pull Request resolved: https://github.com/facebook/rocksdb/pull/4187

Differential Revision: D8996600

Pulled By: siying

fbshipit-source-id: b6235ea614f71381e50e7904c4fb036300604ac1

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/rocksdb/31)
<!-- Reviewable:end -->
