### PR TITLE
Potential fix for stress test failure due to "SST file ahead of WAL" error (#5412)

### DIFF
--- a/db/db_impl_open.cc
+++ b/db/db_impl_open.cc
@@ -541,12 +541,13 @@ Status DBImpl::RecoverLogFiles(const std::vector<uint64_t>& log_numbers,
   bool stop_replay_for_corruption = false;
   bool flushed = false;
   uint64_t corrupted_log_number = kMaxSequenceNumber;
+  uint64_t min_log_number = MinLogNumberToKeep();
   for (auto log_number : log_numbers) {
-    if (log_number < versions_->min_log_number_to_keep_2pc()) {
+    if (log_number < min_log_number) {
       ROCKS_LOG_INFO(immutable_db_options_.info_log,
                      "Skipping log #%" PRIu64
                      " since it is older than min log to keep #%" PRIu64,
-                     log_number, versions_->min_log_number_to_keep_2pc());
+                     log_number, min_log_number);
       continue;
     }
     // The previous incarnation may not have written any MANIFEST


### PR DESCRIPTION
This is an unclean backport of
https://github.com/facebook/rocksdb/pull/5412. I removed the change to
`SyncClosedLogs()` calling `LogWriter::Close()` since our 5.17 branch
does not have `LogWriter::Close()` implemented. I believe this is fine
to omit because we aren't calling `SyncClosedLogs()` during flush in
our single-CF use case.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/rocksdb/34)
<!-- Reviewable:end -->
