### PR TITLE
Initialize pinned_pos_ and pinned_seq_pos_ in FragmentedRangeTombstoneIterator

### DIFF
--- a/db/range_tombstone_fragmenter.h
+++ b/db/range_tombstone_fragmenter.h
@@ -144,6 +144,8 @@ class FragmentedRangeTombstoneIterator : public InternalIterator {
   void Invalidate() {
     pos_ = tombstones_->end();
     seq_pos_ = tombstones_->seq_end();
+    pinned_pos_ = tombstones_->end();
+    pinned_seq_pos_ = tombstones_->seq_end();
   }
 
   RangeTombstone Tombstone() const {


### PR DESCRIPTION
These uninitialized member variables causes a key to not be pinned when it should be, leading to an "external files have corrupted keys" error when ingesting a file with range deletion tombstones on Mac.

Fixes cockroachdb/cockroach#39696.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/rocksdb/44)
<!-- Reviewable:end -->
