### PR TITLE
table: Always check key ordering when inserting to an SST

### DIFF
--- a/table/block_based_table_builder.cc
+++ b/table/block_based_table_builder.cc
@@ -500,11 +500,16 @@ void BlockBasedTableBuilder::Add(const Slice& key, const Slice& value) {
   if (!ok()) return;
   ValueType value_type = ExtractValueType(key);
   if (IsValueType(value_type)) {
-#ifndef NDEBUG
     if (r->props.num_entries > r->props.num_range_deletions) {
-      assert(r->internal_comparator.Compare(key, Slice(r->last_key)) > 0);
+      if (r->internal_comparator.Compare(key, Slice(r->last_key)) <= 0) {
+        // We were about to insert keys out of order. Abort.
+        ROCKS_LOG_ERROR(r->ioptions.info_log,
+                        "Out-of-order key insertion into block based table");
+        r->status =
+            Status::Corruption("Out-of-order key insertion into table");
+        return;
+      }
     }
-#endif  // NDEBUG
 
     auto should_flush = r->flush_block_policy->Update(key, value);
     if (should_flush) {


### PR DESCRIPTION
To prevent an out-of-order SSTable insertion from ever happening, this
change updates BlockBasedTableBuilder::Add to always assert on key
ordering being maintained at the insertion point, rather than only
running with debug builds. When an out-of-order key insertion is
detected, the status is set to Corrupted to prevent the BlockBasedTable
from being written.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/rocksdb/46)
<!-- Reviewable:end -->
