### PR TITLE
[19.1 backport] table: Always check key ordering when inserting to an SST

### DIFF
--- a/table/block_based_table_builder.cc
+++ b/table/block_based_table_builder.cc
@@ -417,7 +417,14 @@ void BlockBasedTableBuilder::Add(const Slice& key, const Slice& value) {
   ValueType value_type = ExtractValueType(key);
   if (IsValueType(value_type)) {
     if (r->props.num_entries > 0) {
-      assert(r->internal_comparator.Compare(key, Slice(r->last_key)) > 0);
+      if (r->internal_comparator.Compare(key, Slice(r->last_key)) <= 0) {
+        // We were about to insert keys out of order. Abort.
+        ROCKS_LOG_ERROR(r->ioptions.info_log,
+                        "Out-of-order key insertion into block based table");
+        r->status =
+            Status::Corruption("Out-of-order key insertion into table");
+        return;
+      }
     }
 
     auto should_flush = r->flush_block_policy->Update(key, value);


### PR DESCRIPTION
Backport of #46.

To prevent an out-of-order SSTable insertion from ever happening, this
change updates BlockBasedTableBuilder::Add to always assert on key
ordering being maintained at the insertion point, rather than only
running with debug builds. When an out-of-order key insertion is
detected, the status is set to Corrupted to prevent the BlockBasedTable
from being written.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/rocksdb/47)
<!-- Reviewable:end -->
