### PR TITLE
Correctly handle FS that does not support hard links

### DIFF
--- a/port/win/env_win.cc
+++ b/port/win/env_win.cc
@@ -731,8 +731,12 @@ Status WinEnvIO::LinkFile(const std::string& src,
 
   if (!RX_CreateHardLink(RX_FN(target).c_str(), RX_FN(src).c_str(),  NULL)) {
     DWORD lastError = GetLastError();
-    if (lastError == ERROR_NOT_SAME_DEVICE) {
-      return Status::NotSupported("No cross FS links allowed");
+    switch (lastError) {
+      case ERROR_NOT_SAME_DEVICE:
+        return Status::NotSupported("No cross FS links allowed");
+      case ERROR_INVALID_FUNCTION: // FS (ex FAT32) doesn't support hard linking.
+      case ERROR_INVALID_PARAMETER: // Network drive doesn't support hard linking.
+        return Status::NotSupported("FS does not support hard links");
     }
 
     std::string text("Failed to link: ");


### PR DESCRIPTION
Ingesting a file from a file system that doesn't
support hard links or from a network location, returns
an error that wasn't handled correctly and the result was
IO error instead of Not Supported status.

Fixes #38789

Release justification: Category 2: Bug fixes and low-risk updates to new functionality.

Release note (bug fix): Fixes an issue with creating table indexes
when the server is running on Windows and the store is on a FS
that does not support hard links (ex FAT32 or network share)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/rocksdb/55)
<!-- Reviewable:end -->
