### PR TITLE
Disable TLS for MINGW due to issues with the order of freeing up memory.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -243,6 +243,7 @@ elseif(FORCE_SSE42)
   message(FATAL_ERROR "FORCE_SSE42=ON but unable to compile with SSE4.2 enabled")
 endif()
 
+if(NOT MINGW)
 CHECK_CXX_SOURCE_COMPILES("
 #if defined(_MSC_VER) && !defined(__thread)
 #define __thread __declspec(thread)
@@ -253,6 +254,7 @@ int main() {
 " HAVE_THREAD_LOCAL)
 if(HAVE_THREAD_LOCAL)
   add_definitions(-DROCKSDB_SUPPORT_THREAD_LOCAL)
+endif()
 endif()
 
 option(FAIL_ON_WARNINGS "Treat compile warnings as errors" ON)


### PR DESCRIPTION
There seems to be an issue with the way MINGW frees up TLS memory. More specifically - the TLS is freed up before the destructors on the objects residing in TLS are called. In our case - we were observing a destructor accessing a block of memory that was already freed.

Here is a report from end uses that seems to be related https://sourceforge.net/p/mingw-w64/bugs/727/

Fixes cockroachdb/cockroach#40936
Fixes cockroachdb/cockroach#40925

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/rocksdb/57)
<!-- Reviewable:end -->
