### PR TITLE
table_cache: Generate unique ID based on db instance, file number

### DIFF
--- a/db/table_cache.cc
+++ b/db/table_cache.cc
@@ -72,7 +72,8 @@ TableCache::TableCache(const ImmutableCFOptions& ioptions,
     : ioptions_(ioptions),
       env_options_(env_options),
       cache_(cache),
-      immortal_tables_(false) {
+      immortal_tables_(false),
+      cache_id_(cache_id_alloc++) {
   if (ioptions_.row_cache) {
     // If the same cache is shared by multiple instances, we need to
     // disambiguate its entries.
@@ -82,6 +83,8 @@ TableCache::TableCache(const ImmutableCFOptions& ioptions,
 
 TableCache::~TableCache() {
 }
+
+std::atomic<uint64_t> TableCache::cache_id_alloc(0);
 
 TableReader* TableCache::GetTableReaderFromHandle(Cache::Handle* handle) {
   return reinterpret_cast<TableReader*>(cache_->Value(handle));
@@ -115,6 +118,13 @@ Status TableCache::GetTableReader(
     if (!sequential_mode && ioptions_.advise_random_on_open) {
       file->Hint(RandomAccessFile::RANDOM);
     }
+
+    // Generate a unique ID for this file, consisting of <cache_id,file_number>.
+    std::string file_id;
+    PutVarint64(&file_id, cache_id_);
+    PutVarint64(&file_id, fd.GetNumber());
+    file->SetUniqueId(std::move(file_id));
+
     StopWatch sw(ioptions_.env, ioptions_.statistics, TABLE_OPEN_IO_MICROS);
     std::unique_ptr<RandomAccessFileReader> file_reader(
         new RandomAccessFileReader(

--- a/db/table_cache.h
+++ b/db/table_cache.h
@@ -162,6 +162,9 @@ class TableCache {
   Cache* const cache_;
   std::string row_cache_id_;
   bool immortal_tables_;
+  const uint64_t cache_id_;
+
+  static std::atomic<uint64_t> cache_id_alloc;
 };
 
 }  // namespace rocksdb

--- a/env/env_test.cc
+++ b/env/env_test.cc
@@ -678,11 +678,6 @@ TEST_P(EnvPosixTestWithParam, DecreaseNumBgThreads) {
   WaitThreadPoolsEmpty();
 }
 
-#if (defined OS_LINUX || defined OS_WIN)
-// Travis doesn't support fallocate or getting unique ID from files for whatever
-// reason.
-#ifndef TRAVIS
-
 namespace {
 bool IsSingleVarint(const std::string& s) {
   Slice slice(s);
@@ -702,8 +697,27 @@ bool IsUniqueIDValid(const std::string& s) {
 const size_t MAX_ID_SIZE = 100;
 char temp_id[MAX_ID_SIZE];
 
-
 }  // namespace
+
+// Returns true if any of the strings in ss are the prefix of another string.
+bool HasPrefix(const std::unordered_set<std::string>& ss) {
+  for (const std::string& s: ss) {
+    if (s.empty()) {
+      return true;
+    }
+    for (size_t i = 1; i < s.size(); ++i) {
+      if (ss.count(s.substr(0, i)) != 0) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+#if (defined OS_LINUX || defined OS_WIN)
+// Travis doesn't support fallocate or getting unique ID from files for whatever
+// reason.
+#ifndef TRAVIS
 
 // Determine whether we can use the FS_IOC_GETVERSION ioctl
 // on a file in directory DIR.  Create a temporary file therein,
@@ -843,50 +857,6 @@ TEST_F(EnvPosixTest, PositionedAppend) {
 }
 #endif  // !ROCKSDB_LITE
 
-// Only works in linux platforms
-TEST_P(EnvPosixTestWithParam, RandomAccessUniqueID) {
-  // Create file.
-  if (env_ == Env::Default()) {
-    EnvOptions soptions;
-    soptions.use_direct_reads = soptions.use_direct_writes = direct_io_;
-    IoctlFriendlyTmpdir ift;
-    std::string fname = ift.name() + "/testfile";
-    std::unique_ptr<WritableFile> wfile;
-    ASSERT_OK(env_->NewWritableFile(fname, &wfile, soptions));
-
-    std::unique_ptr<RandomAccessFile> file;
-
-    // Get Unique ID
-    ASSERT_OK(env_->NewRandomAccessFile(fname, &file, soptions));
-    size_t id_size = file->GetUniqueId(temp_id, MAX_ID_SIZE);
-    ASSERT_TRUE(id_size > 0);
-    std::string unique_id1(temp_id, id_size);
-    ASSERT_TRUE(IsUniqueIDValid(unique_id1));
-
-    // Get Unique ID again
-    ASSERT_OK(env_->NewRandomAccessFile(fname, &file, soptions));
-    id_size = file->GetUniqueId(temp_id, MAX_ID_SIZE);
-    ASSERT_TRUE(id_size > 0);
-    std::string unique_id2(temp_id, id_size);
-    ASSERT_TRUE(IsUniqueIDValid(unique_id2));
-
-    // Get Unique ID again after waiting some time.
-    env_->SleepForMicroseconds(1000000);
-    ASSERT_OK(env_->NewRandomAccessFile(fname, &file, soptions));
-    id_size = file->GetUniqueId(temp_id, MAX_ID_SIZE);
-    ASSERT_TRUE(id_size > 0);
-    std::string unique_id3(temp_id, id_size);
-    ASSERT_TRUE(IsUniqueIDValid(unique_id3));
-
-    // Check IDs are the same.
-    ASSERT_EQ(unique_id1, unique_id2);
-    ASSERT_EQ(unique_id2, unique_id3);
-
-    // Delete the file
-    env_->DeleteFile(fname);
-  }
-}
-
 // only works in linux platforms
 #ifdef ROCKSDB_FALLOCATE_PRESENT
 TEST_P(EnvPosixTestWithParam, AllocateTest) {
@@ -961,104 +931,6 @@ TEST_P(EnvPosixTestWithParam, AllocateTest) {
 }
 #endif  // ROCKSDB_FALLOCATE_PRESENT
 
-// Returns true if any of the strings in ss are the prefix of another string.
-bool HasPrefix(const std::unordered_set<std::string>& ss) {
-  for (const std::string& s: ss) {
-    if (s.empty()) {
-      return true;
-    }
-    for (size_t i = 1; i < s.size(); ++i) {
-      if (ss.count(s.substr(0, i)) != 0) {
-        return true;
-      }
-    }
-  }
-  return false;
-}
-
-// Only works in linux and WIN platforms
-TEST_P(EnvPosixTestWithParam, RandomAccessUniqueIDConcurrent) {
-  if (env_ == Env::Default()) {
-    // Check whether a bunch of concurrently existing files have unique IDs.
-    EnvOptions soptions;
-    soptions.use_direct_reads = soptions.use_direct_writes = direct_io_;
-
-    // Create the files
-    IoctlFriendlyTmpdir ift;
-    std::vector<std::string> fnames;
-    for (int i = 0; i < 1000; ++i) {
-      fnames.push_back(ift.name() + "/" + "testfile" + ToString(i));
-
-      // Create file.
-      std::unique_ptr<WritableFile> wfile;
-      ASSERT_OK(env_->NewWritableFile(fnames[i], &wfile, soptions));
-    }
-
-    // Collect and check whether the IDs are unique.
-    std::unordered_set<std::string> ids;
-    for (const std::string fname : fnames) {
-      std::unique_ptr<RandomAccessFile> file;
-      std::string unique_id;
-      ASSERT_OK(env_->NewRandomAccessFile(fname, &file, soptions));
-      size_t id_size = file->GetUniqueId(temp_id, MAX_ID_SIZE);
-      ASSERT_TRUE(id_size > 0);
-      unique_id = std::string(temp_id, id_size);
-      ASSERT_TRUE(IsUniqueIDValid(unique_id));
-
-      ASSERT_TRUE(ids.count(unique_id) == 0);
-      ids.insert(unique_id);
-    }
-
-    // Delete the files
-    for (const std::string fname : fnames) {
-      ASSERT_OK(env_->DeleteFile(fname));
-    }
-
-    ASSERT_TRUE(!HasPrefix(ids));
-  }
-}
-
-// Only works in linux and WIN platforms
-TEST_P(EnvPosixTestWithParam, RandomAccessUniqueIDDeletes) {
-  if (env_ == Env::Default()) {
-    EnvOptions soptions;
-    soptions.use_direct_reads = soptions.use_direct_writes = direct_io_;
-
-    IoctlFriendlyTmpdir ift;
-    std::string fname = ift.name() + "/" + "testfile";
-
-    // Check that after file is deleted we don't get same ID again in a new
-    // file.
-    std::unordered_set<std::string> ids;
-    for (int i = 0; i < 1000; ++i) {
-      // Create file.
-      {
-        std::unique_ptr<WritableFile> wfile;
-        ASSERT_OK(env_->NewWritableFile(fname, &wfile, soptions));
-      }
-
-      // Get Unique ID
-      std::string unique_id;
-      {
-        std::unique_ptr<RandomAccessFile> file;
-        ASSERT_OK(env_->NewRandomAccessFile(fname, &file, soptions));
-        size_t id_size = file->GetUniqueId(temp_id, MAX_ID_SIZE);
-        ASSERT_TRUE(id_size > 0);
-        unique_id = std::string(temp_id, id_size);
-      }
-
-      ASSERT_TRUE(IsUniqueIDValid(unique_id));
-      ASSERT_TRUE(ids.count(unique_id) == 0);
-      ids.insert(unique_id);
-
-      // Delete the file
-      ASSERT_OK(env_->DeleteFile(fname));
-    }
-
-    ASSERT_TRUE(!HasPrefix(ids));
-  }
-}
-
 // Only works in linux platforms
 #ifdef OS_WIN
 TEST_P(EnvPosixTestWithParam, DISABLED_InvalidateCache) {
@@ -1131,6 +1003,135 @@ TEST_P(EnvPosixTestWithParam, InvalidateCache) {
 }
 #endif  // not TRAVIS
 #endif  // OS_LINUX || OS_WIN
+
+// The following 3 tests don't actually test ID generation since we call
+// SetUniqueId, but it tries to mimic the ID setting code in TableCache as much
+// as possible while still testing the getter/setter code.
+TEST_P(EnvPosixTestWithParam, RandomAccessUniqueID) {
+  // Create file.
+  if (env_ == Env::Default()) {
+    EnvOptions soptions;
+    soptions.use_direct_reads = soptions.use_direct_writes = direct_io_;
+    std::string fname = test::TmpDir(env_) + "/" + + "/testfile";
+    std::unique_ptr<WritableFile> wfile;
+    ASSERT_OK(env_->NewWritableFile(fname, &wfile, soptions));
+
+    std::unique_ptr<RandomAccessFile> file;
+    std::string unique_id;
+    PutVarint64(&unique_id, 1000);
+    PutVarint64(&unique_id, 1001);
+
+    // Get Unique ID
+    ASSERT_OK(env_->NewRandomAccessFile(fname, &file, soptions));
+    size_t id_size = file->GetUniqueId(temp_id, MAX_ID_SIZE);
+    ASSERT_TRUE(id_size == 0);
+
+    // Set a unique ID, then try getting it again.
+    file->SetUniqueId(unique_id);
+    id_size = file->GetUniqueId(temp_id, MAX_ID_SIZE);
+    ASSERT_TRUE(id_size > 0);
+    std::string unique_id1(temp_id, id_size);
+    ASSERT_TRUE(IsUniqueIDValid(unique_id1));
+
+    // Get Unique ID again
+    id_size = file->GetUniqueId(temp_id, MAX_ID_SIZE);
+    ASSERT_TRUE(id_size > 0);
+    std::string unique_id2(temp_id, id_size);
+    ASSERT_TRUE(IsUniqueIDValid(unique_id2));
+
+    // Check IDs are the same.
+    ASSERT_EQ(unique_id1, unique_id2);
+
+    // Delete the file
+    env_->DeleteFile(fname);
+  }
+}
+
+TEST_P(EnvPosixTestWithParam, RandomAccessUniqueIDConcurrent) {
+  if (env_ == Env::Default()) {
+    // Check whether a bunch of concurrently existing files have unique IDs.
+    EnvOptions soptions;
+    soptions.use_direct_reads = soptions.use_direct_writes = direct_io_;
+
+    // Create the files
+    std::vector<std::string> fnames;
+    for (int i = 0; i < 1000; ++i) {
+      fnames.push_back(test::TmpDir(env_) + "/" + "testfile" + ToString(i));
+
+      // Create file.
+      std::unique_ptr<WritableFile> wfile;
+      ASSERT_OK(env_->NewWritableFile(fnames[i], &wfile, soptions));
+    }
+
+    // Collect and check whether the IDs are unique.
+    std::unordered_set<std::string> ids;
+    int counter = 0;
+    for (const std::string fname : fnames) {
+      std::unique_ptr<RandomAccessFile> file;
+      std::string unique_id;
+      ASSERT_OK(env_->NewRandomAccessFile(fname, &file, soptions));
+      PutVarint64(&unique_id, 1000);
+      PutVarint64(&unique_id, counter++);
+      file->SetUniqueId(unique_id);
+      size_t id_size = file->GetUniqueId(temp_id, MAX_ID_SIZE);
+      ASSERT_TRUE(id_size > 0);
+      unique_id = std::string(temp_id, id_size);
+      ASSERT_TRUE(IsUniqueIDValid(unique_id));
+
+      ASSERT_TRUE(ids.count(unique_id) == 0);
+      ids.insert(unique_id);
+    }
+
+    // Delete the files
+    for (const std::string fname : fnames) {
+      ASSERT_OK(env_->DeleteFile(fname));
+    }
+
+    ASSERT_TRUE(!HasPrefix(ids));
+  }
+}
+
+TEST_P(EnvPosixTestWithParam, RandomAccessUniqueIDDeletes) {
+  if (env_ == Env::Default()) {
+    EnvOptions soptions;
+    soptions.use_direct_reads = soptions.use_direct_writes = direct_io_;
+
+    std::string fname = test::TmpDir(env_) + "/" + + "testfile";
+
+    // Check that after file is deleted we don't get same ID again in a new
+    // file.
+    std::unordered_set<std::string> ids;
+    for (int i = 0; i < 1000; ++i) {
+      // Create file.
+      {
+        std::unique_ptr<WritableFile> wfile;
+        ASSERT_OK(env_->NewWritableFile(fname, &wfile, soptions));
+      }
+
+      // Get Unique ID
+      std::string unique_id;
+      {
+        std::unique_ptr<RandomAccessFile> file;
+        ASSERT_OK(env_->NewRandomAccessFile(fname, &file, soptions));
+        PutVarint64(&unique_id, 1000);
+        PutVarint64(&unique_id, i);
+        file->SetUniqueId(unique_id);
+        size_t id_size = file->GetUniqueId(temp_id, MAX_ID_SIZE);
+        ASSERT_TRUE(id_size > 0);
+        unique_id = std::string(temp_id, id_size);
+      }
+
+      ASSERT_TRUE(IsUniqueIDValid(unique_id));
+      ASSERT_TRUE(ids.count(unique_id) == 0);
+      ids.insert(unique_id);
+
+      // Delete the file
+      ASSERT_OK(env_->DeleteFile(fname));
+    }
+
+    ASSERT_TRUE(!HasPrefix(ids));
+  }
+}
 
 class TestLogger : public Logger {
  public:

--- a/env/io_posix.cc
+++ b/env/io_posix.cc
@@ -301,58 +301,6 @@ Status PosixSequentialFile::InvalidateCache(size_t offset, size_t length) {
 
 /*
  * PosixRandomAccessFile
- */
-#if defined(OS_LINUX)
-size_t PosixHelper::GetUniqueIdFromFile(int fd, char* id, size_t max_size) {
-  if (max_size < kMaxVarint64Length * 3) {
-    return 0;
-  }
-
-  struct stat buf;
-  int result = fstat(fd, &buf);
-  if (result == -1) {
-    return 0;
-  }
-
-  long version = 0;
-  result = ioctl(fd, FS_IOC_GETVERSION, &version);
-  TEST_SYNC_POINT_CALLBACK("GetUniqueIdFromFile:FS_IOC_GETVERSION", &result);
-  if (result == -1) {
-    return 0;
-  }
-  uint64_t uversion = (uint64_t)version;
-
-  char* rid = id;
-  rid = EncodeVarint64(rid, buf.st_dev);
-  rid = EncodeVarint64(rid, buf.st_ino);
-  rid = EncodeVarint64(rid, uversion);
-  assert(rid >= id);
-  return static_cast<size_t>(rid - id);
-}
-#endif
-
-#if defined(OS_MACOSX) || defined(OS_AIX)
-size_t PosixHelper::GetUniqueIdFromFile(int fd, char* id, size_t max_size) {
-  if (max_size < kMaxVarint64Length * 3) {
-    return 0;
-  }
-
-  struct stat buf;
-  int result = fstat(fd, &buf);
-  if (result == -1) {
-    return 0;
-  }
-
-  char* rid = id;
-  rid = EncodeVarint64(rid, buf.st_dev);
-  rid = EncodeVarint64(rid, buf.st_ino);
-  rid = EncodeVarint64(rid, buf.st_gen);
-  assert(rid >= id);
-  return static_cast<size_t>(rid - id);
-}
-#endif
-/*
- * PosixRandomAccessFile
  *
  * pread() based random-access
  */
@@ -428,12 +376,6 @@ Status PosixRandomAccessFile::Prefetch(uint64_t offset, size_t n) {
   }
   return s;
 }
-
-#if defined(OS_LINUX) || defined(OS_MACOSX) || defined(OS_AIX)
-size_t PosixRandomAccessFile::GetUniqueId(char* id, size_t max_size) const {
-  return PosixHelper::GetUniqueIdFromFile(fd_, id, max_size);
-}
-#endif
 
 void PosixRandomAccessFile::Hint(AccessPattern pattern) {
   if (use_direct_io()) {
@@ -1020,12 +962,6 @@ Status PosixWritableFile::RangeSync(uint64_t offset, uint64_t nbytes) {
 #endif  // ROCKSDB_RANGESYNC_PRESENT
   return WritableFile::RangeSync(offset, nbytes);
 }
-
-#ifdef OS_LINUX
-size_t PosixWritableFile::GetUniqueId(char* id, size_t max_size) const {
-  return PosixHelper::GetUniqueIdFromFile(fd_, id, max_size);
-}
-#endif
 
 /*
  * PosixRandomRWFile

--- a/env/io_posix.h
+++ b/env/io_posix.h
@@ -50,11 +50,6 @@ static Status IOError(const std::string& context, const std::string& file_name,
   }
 }
 
-class PosixHelper {
- public:
-  static size_t GetUniqueIdFromFile(int fd, char* id, size_t max_size);
-};
-
 class PosixSequentialFile : public SequentialFile {
  private:
   std::string filename_;
@@ -96,9 +91,6 @@ class PosixRandomAccessFile : public RandomAccessFile {
 
   virtual Status Prefetch(uint64_t offset, size_t n) override;
 
-#if defined(OS_LINUX) || defined(OS_MACOSX) || defined(OS_AIX)
-  virtual size_t GetUniqueId(char* id, size_t max_size) const override;
-#endif
   virtual void Hint(AccessPattern pattern) override;
   virtual Status InvalidateCache(size_t offset, size_t length) override;
   virtual bool use_direct_io() const override { return use_direct_io_; }
@@ -150,9 +142,6 @@ class PosixWritableFile : public WritableFile {
   virtual Status Allocate(uint64_t offset, uint64_t len) override;
 #endif
   virtual Status RangeSync(uint64_t offset, uint64_t nbytes) override;
-#ifdef OS_LINUX
-  virtual size_t GetUniqueId(char* id, size_t max_size) const override;
-#endif
 };
 
 // mmap() based random-access

--- a/include/rocksdb/env.h
+++ b/include/rocksdb/env.h
@@ -572,6 +572,8 @@ class SequentialFile {
 
 // A file abstraction for randomly reading the contents of a file.
 class RandomAccessFile {
+ private:
+  std::string unique_id_;
  public:
   RandomAccessFile() {}
   virtual ~RandomAccessFile();
@@ -609,10 +611,18 @@ class RandomAccessFile {
   // a single varint.
   //
   // Note: these IDs are only valid for the duration of the process.
-  virtual size_t GetUniqueId(char* /*id*/, size_t /*max_size*/) const {
-    return 0;  // Default implementation to prevent issues with backwards
-               // compatibility.
-  };
+  virtual size_t GetUniqueId(char* id, size_t max_size) const {
+    if (max_size >= unique_id_.length()) {
+      memcpy(id, unique_id_.data(), unique_id_.length());
+      return unique_id_.length();
+    }
+    return 0;
+  }
+
+  // Sets a unique ID for this file that could be returned in GetUniqueId.
+  virtual void SetUniqueId(std::string unique_id) {
+    unique_id_ = std::move(unique_id);
+  }
 
   enum AccessPattern { NORMAL, RANDOM, SEQUENTIAL, WILLNEED, DONTNEED };
 
@@ -751,8 +761,17 @@ class WritableFile {
   }
 
   // For documentation, refer to RandomAccessFile::GetUniqueId()
-  virtual size_t GetUniqueId(char* /*id*/, size_t /*max_size*/) const {
-    return 0;  // Default implementation to prevent issues with backwards
+  virtual size_t GetUniqueId(char* id, size_t max_size) const {
+    if (max_size >= unique_id_.length()) {
+      memcpy(id, unique_id_.data(), unique_id_.length());
+      return unique_id_.length();
+    }
+    return 0;
+  }
+
+  // Sets a unique ID for this file that could be returned in GetUniqueId.
+  virtual void SetUniqueId(std::string unique_id) {
+    unique_id_ = unique_id;
   }
 
   // Remove any kind of caching of data from the offset to offset+length
@@ -814,6 +833,7 @@ class WritableFile {
  private:
   size_t last_preallocated_block_;
   size_t preallocation_block_size_;
+  std::string unique_id_;
   // No copying allowed
   WritableFile(const WritableFile&);
   void operator=(const WritableFile&);
@@ -1321,6 +1341,9 @@ class RandomAccessFileWrapper : public RandomAccessFile {
   size_t GetUniqueId(char* id, size_t max_size) const override {
     return target_->GetUniqueId(id, max_size);
   };
+  void SetUniqueId(std::string unique_id) override {
+    target_->SetUniqueId(unique_id);
+  }
   void Hint(AccessPattern pattern) override { target_->Hint(pattern); }
   bool use_direct_io() const override { return target_->use_direct_io(); }
   size_t GetRequiredBufferAlignment() const override {
@@ -1382,6 +1405,10 @@ class WritableFileWrapper : public WritableFile {
 
   size_t GetUniqueId(char* id, size_t max_size) const override {
     return target_->GetUniqueId(id, max_size);
+  }
+
+  void SetUniqueId(std::string unique_id) override {
+    target_->SetUniqueId(unique_id);
   }
 
   Status InvalidateCache(size_t offset, size_t length) override {

--- a/port/win/io_win.cc
+++ b/port/win/io_win.cc
@@ -175,19 +175,6 @@ Status ftruncate(const std::string& filename, HANDLE hFile,
   return status;
 }
 
-size_t GetUniqueIdFromFile(HANDLE /*hFile*/, char* /*id*/, size_t /*max_size*/) {
-  // `FileIdInfo` is not supported. The possible alternative,
-  // `BY_HANDLE_FILE_INFORMATION::nFileIndex{High,Low}`, allows deleted files'
-  // IDs to be reused for newly created files. Since we don't evict from block
-  // cache before deleting a file, this introduces a risk that readers access
-  // obsolete data blocks.
-  //
-  // Returning 0 is safe as it causes the table reader to generate a unique ID.
-  // This is suboptimal for performance as it prevents multiple table readers
-  // for the same file from sharing cached blocks, but at least it's safe.
-  return 0;
-}
-
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // WinMmapReadableFile
 
@@ -226,10 +213,6 @@ Status WinMmapReadableFile::Read(uint64_t offset, size_t n, Slice* result,
 
 Status WinMmapReadableFile::InvalidateCache(size_t offset, size_t length) {
   return Status::OK();
-}
-
-size_t WinMmapReadableFile::GetUniqueId(char* id, size_t max_size) const {
-  return GetUniqueIdFromFile(hFile_, id, max_size);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -552,10 +535,6 @@ Status WinMmapFile::Allocate(uint64_t offset, uint64_t len) {
   return status;
 }
 
-size_t WinMmapFile::GetUniqueId(char* id, size_t max_size) const {
-  return GetUniqueIdFromFile(hFile_, id, max_size);
-}
-
 //////////////////////////////////////////////////////////////////////////////////
 // WinSequentialFile
 
@@ -717,10 +696,6 @@ Status WinRandomAccessFile::Read(uint64_t offset, size_t n, Slice* result,
 
 Status WinRandomAccessFile::InvalidateCache(size_t offset, size_t length) {
   return Status::OK();
-}
-
-size_t WinRandomAccessFile::GetUniqueId(char* id, size_t max_size) const {
-  return GetUniqueIdFromFile(GetFileHandle(), id, max_size);
 }
 
 size_t WinRandomAccessFile::GetRequiredBufferAlignment() const {
@@ -980,10 +955,6 @@ Status WinWritableFile::Allocate(uint64_t offset, uint64_t len) {
   return AllocateImpl(offset, len);
 }
 
-size_t WinWritableFile::GetUniqueId(char* id, size_t max_size) const {
-  return GetUniqueIdFromFile(GetFileHandle(), id, max_size);
-}
-
 /////////////////////////////////////////////////////////////////////////
 /// WinRandomRWFile
 
@@ -1046,10 +1017,6 @@ WinMemoryMappedBuffer::~WinMemoryMappedBuffer() {
 /// WinDirectory
 
 Status WinDirectory::Fsync() { return Status::OK(); }
-
-size_t WinDirectory::GetUniqueId(char* id, size_t max_size) const {
-  return GetUniqueIdFromFile(handle_, id, max_size);
-}
 //////////////////////////////////////////////////////////////////////////
 /// WinFileLock
 

--- a/port/win/io_win.h
+++ b/port/win/io_win.h
@@ -56,8 +56,6 @@ Status fallocate(const std::string& filename, HANDLE hFile, uint64_t to_size);
 
 Status ftruncate(const std::string& filename, HANDLE hFile, uint64_t toSize);
 
-size_t GetUniqueIdFromFile(HANDLE hFile, char* id, size_t max_size);
-
 class WinFileData {
  protected:
   const std::string filename_;
@@ -143,8 +141,6 @@ class WinMmapReadableFile : private WinFileData, public RandomAccessFile {
                       char* scratch) const override;
 
   virtual Status InvalidateCache(size_t offset, size_t length) override;
-
-  virtual size_t GetUniqueId(char* id, size_t max_size) const override;
 };
 
 // We preallocate and use memcpy to append new
@@ -225,8 +221,6 @@ class WinMmapFile : private WinFileData, public WritableFile {
   virtual Status InvalidateCache(size_t offset, size_t length) override;
 
   virtual Status Allocate(uint64_t offset, uint64_t len) override;
-
-  virtual size_t GetUniqueId(char* id, size_t max_size) const override;
 };
 
 class WinRandomAccessImpl {
@@ -268,8 +262,6 @@ class WinRandomAccessFile
 
   virtual Status Read(uint64_t offset, size_t n, Slice* result,
                       char* scratch) const override;
-
-  virtual size_t GetUniqueId(char* id, size_t max_size) const override;
 
   virtual bool use_direct_io() const override { return WinFileData::use_direct_io(); }
 
@@ -374,8 +366,6 @@ class WinWritableFile : private WinFileData,
   virtual uint64_t GetFileSize() override;
 
   virtual Status Allocate(uint64_t offset, uint64_t len) override;
-
-  virtual size_t GetUniqueId(char* id, size_t max_size) const override;
 };
 
 class WinRandomRWFile : private WinFileData,
@@ -437,8 +427,6 @@ class WinDirectory : public Directory {
     ::CloseHandle(handle_);
   }
   virtual Status Fsync() override;
-
-  size_t GetUniqueId(char* id, size_t max_size) const override;
 };
 
 class WinFileLock : public FileLock {


### PR DESCRIPTION
This change updates the cache key prefix for SST files from relying
on the inode generation number to using a passed-in unique ID. This
ID is composed of a table-cache-specific random ID, as well as the
number of the SST. This should resolve issues around cache collisions
between two different SS tables that happened to have the same
generation number.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/rocksdb/61)
<!-- Reviewable:end -->
