### PR TITLE
[2.0 backport] table_cache: Generate SST file cache key based on db instance, file num

### DIFF
--- a/db/db_test2.cc
+++ b/db/db_test2.cc
@@ -1808,6 +1808,18 @@ TEST_F(DBTest2, ReadAmpBitmapLiveInCacheAfterDBClose) {
     // the blocks again regardless of them being already in the cache
     return;
   }
+  {
+    std::unique_ptr<RandomAccessFile> file;
+    const int kIdBufLen = 100;
+    char id_buf[kIdBufLen];
+    ASSERT_OK(env_->NewRandomAccessFile(dbname_, &file, EnvOptions()));
+    if (file->GetUniqueId(id_buf, kIdBufLen) == 0) {
+      // fs holding db directory doesn't support getting a unique file id,
+      // this means that running this test will fail because lru_cache will load
+      // the blocks again regardless of them being already in the cache
+      return;
+    }
+  }
   uint32_t bytes_per_bit[2] = {1, 16};
   for (size_t k = 0; k < 2; k++) {
     std::shared_ptr<Cache> lru_cache = NewLRUCache(1024 * 1024 * 1024);

--- a/db/table_cache.cc
+++ b/db/table_cache.cc
@@ -65,7 +65,10 @@ void AppendVarint64(IterKey* key, uint64_t v) {
 
 TableCache::TableCache(const ImmutableCFOptions& ioptions,
                        const EnvOptions& env_options, Cache* const cache)
-    : ioptions_(ioptions), env_options_(env_options), cache_(cache) {
+    : ioptions_(ioptions),
+      env_options_(env_options),
+      cache_(cache),
+      cache_id_(cache_id_alloc++) {
   if (ioptions_.row_cache) {
     // If the same cache is shared by multiple instances, we need to
     // disambiguate its entries.
@@ -75,6 +78,8 @@ TableCache::TableCache(const ImmutableCFOptions& ioptions,
 
 TableCache::~TableCache() {
 }
+
+std::atomic<uint64_t> TableCache::cache_id_alloc(0);
 
 TableReader* TableCache::GetTableReaderFromHandle(Cache::Handle* handle) {
   return reinterpret_cast<TableReader*>(cache_->Value(handle));
@@ -104,6 +109,13 @@ Status TableCache::GetTableReader(
     if (!sequential_mode && ioptions_.advise_random_on_open) {
       file->Hint(RandomAccessFile::RANDOM);
     }
+
+    // Generate a unique ID for this file, consisting of <cache_id,file_number>.
+    std::string file_id;
+    PutVarint64(&file_id, cache_id_);
+    PutVarint64(&file_id, fd.GetNumber());
+    file->SetUniqueId(std::move(file_id));
+
     StopWatch sw(ioptions_.env, ioptions_.statistics, TABLE_OPEN_IO_MICROS);
     std::unique_ptr<RandomAccessFileReader> file_reader(
         new RandomAccessFileReader(

--- a/db/table_cache.h
+++ b/db/table_cache.h
@@ -141,6 +141,9 @@ class TableCache {
   const EnvOptions& env_options_;
   Cache* const cache_;
   std::string row_cache_id_;
+  const uint64_t cache_id_;
+
+  static std::atomic<uint64_t> cache_id_alloc;
 };
 
 }  // namespace rocksdb

--- a/env/env_test.cc
+++ b/env/env_test.cc
@@ -560,11 +560,6 @@ TEST_P(EnvPosixTestWithParam, DecreaseNumBgThreads) {
   WaitThreadPoolsEmpty();
 }
 
-#if (defined OS_LINUX || defined OS_WIN)
-// Travis doesn't support fallocate or getting unique ID from files for whatever
-// reason.
-#ifndef TRAVIS
-
 namespace {
 bool IsSingleVarint(const std::string& s) {
   Slice slice(s);
@@ -586,6 +581,152 @@ char temp_id[MAX_ID_SIZE];
 
 
 }  // namespace
+
+// Returns true if any of the strings in ss are the prefix of another string.
+bool HasPrefix(const std::unordered_set<std::string>& ss) {
+  for (const std::string& s: ss) {
+    if (s.empty()) {
+      return true;
+    }
+    for (size_t i = 1; i < s.size(); ++i) {
+      if (ss.count(s.substr(0, i)) != 0) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+TEST_P(EnvPosixTestWithParam, RandomAccessUniqueID) {
+  // Create file.
+  if (env_ == Env::Default()) {
+    EnvOptions soptions;
+    soptions.use_direct_reads = soptions.use_direct_writes = direct_io_;
+    std::string fname = test::TmpDir(env_) + "/" + + "/testfile";
+    unique_ptr<WritableFile> wfile;
+    ASSERT_OK(env_->NewWritableFile(fname, &wfile, soptions));
+
+    unique_ptr<RandomAccessFile> file;
+
+    // Get Unique ID
+    ASSERT_OK(env_->NewRandomAccessFile(fname, &file, soptions));
+    size_t id_size = file->GetUniqueId(temp_id, MAX_ID_SIZE);
+    ASSERT_TRUE(id_size == 0);
+
+    std::string unique_id;
+    PutVarint64(&unique_id, 1000);
+    PutVarint64(&unique_id, 1001);
+    file->SetUniqueId(unique_id);
+
+    id_size = file->GetUniqueId(temp_id, MAX_ID_SIZE);
+    ASSERT_TRUE(id_size > 0);
+    std::string unique_id1(temp_id, id_size);
+    ASSERT_TRUE(IsUniqueIDValid(unique_id1));
+
+    // Get Unique ID again
+    id_size = file->GetUniqueId(temp_id, MAX_ID_SIZE);
+    ASSERT_TRUE(id_size > 0);
+    std::string unique_id2(temp_id, id_size);
+    ASSERT_TRUE(IsUniqueIDValid(unique_id2));
+
+    // Check IDs are the same.
+    ASSERT_EQ(unique_id1, unique_id2);
+
+    // Delete the file
+    env_->DeleteFile(fname);
+  }
+}
+
+TEST_P(EnvPosixTestWithParam, RandomAccessUniqueIDConcurrent) {
+  if (env_ == Env::Default()) {
+    // Check whether a bunch of concurrently existing files have unique IDs.
+    EnvOptions soptions;
+    soptions.use_direct_reads = soptions.use_direct_writes = direct_io_;
+
+    // Create the files
+    std::vector<std::string> fnames;
+    for (int i = 0; i < 1000; ++i) {
+      fnames.push_back(test::TmpDir(env_) + "/" + "testfile" + ToString(i));
+
+      // Create file.
+      unique_ptr<WritableFile> wfile;
+      ASSERT_OK(env_->NewWritableFile(fnames[i], &wfile, soptions));
+    }
+
+    // Collect and check whether the IDs are unique.
+    std::unordered_set<std::string> ids;
+    int counter = 0;
+    for (const std::string fname : fnames) {
+      unique_ptr<RandomAccessFile> file;
+      std::string unique_id;
+      ASSERT_OK(env_->NewRandomAccessFile(fname, &file, soptions));
+      PutVarint64(&unique_id, 1000);
+      PutVarint64(&unique_id, counter++);
+      file->SetUniqueId(unique_id);
+      size_t id_size = file->GetUniqueId(temp_id, MAX_ID_SIZE);
+      ASSERT_TRUE(id_size > 0);
+      unique_id = std::string(temp_id, id_size);
+      ASSERT_TRUE(IsUniqueIDValid(unique_id));
+
+      ASSERT_TRUE(ids.count(unique_id) == 0);
+      ids.insert(unique_id);
+    }
+
+    // Delete the files
+    for (const std::string fname : fnames) {
+      ASSERT_OK(env_->DeleteFile(fname));
+    }
+
+    ASSERT_TRUE(!HasPrefix(ids));
+  }
+}
+
+TEST_P(EnvPosixTestWithParam, RandomAccessUniqueIDDeletes) {
+  if (env_ == Env::Default()) {
+    EnvOptions soptions;
+    soptions.use_direct_reads = soptions.use_direct_writes = direct_io_;
+
+    std::string fname = test::TmpDir(env_) + "/" + "testfile";
+
+    // Check that after file is deleted we don't get same ID again in a new
+    // file.
+    std::unordered_set<std::string> ids;
+    for (int i = 0; i < 1000; ++i) {
+      // Create file.
+      {
+        unique_ptr<WritableFile> wfile;
+        ASSERT_OK(env_->NewWritableFile(fname, &wfile, soptions));
+      }
+
+      // Get Unique ID
+      std::string unique_id;
+      {
+        unique_ptr<RandomAccessFile> file;
+        ASSERT_OK(env_->NewRandomAccessFile(fname, &file, soptions));
+        PutVarint64(&unique_id, 1000);
+        PutVarint64(&unique_id, i);
+        file->SetUniqueId(unique_id);
+        size_t id_size = file->GetUniqueId(temp_id, MAX_ID_SIZE);
+        ASSERT_TRUE(id_size > 0);
+        unique_id = std::string(temp_id, id_size);
+      }
+
+      ASSERT_TRUE(IsUniqueIDValid(unique_id));
+      ASSERT_TRUE(ids.count(unique_id) == 0);
+      ids.insert(unique_id);
+
+      // Delete the file
+      ASSERT_OK(env_->DeleteFile(fname));
+    }
+
+    ASSERT_TRUE(!HasPrefix(ids));
+  }
+}
+
+#if (defined OS_LINUX || defined OS_WIN)
+// Travis doesn't support fallocate or getting unique ID from files for whatever
+// reason.
+#ifndef TRAVIS
 
 // Determine whether we can use the FS_IOC_GETVERSION ioctl
 // on a file in directory DIR.  Create a temporary file therein,
@@ -725,50 +866,6 @@ TEST_F(EnvPosixTest, PositionedAppend) {
 }
 #endif  // !ROCKSDB_LITE
 
-// Only works in linux platforms
-TEST_P(EnvPosixTestWithParam, RandomAccessUniqueID) {
-  // Create file.
-  if (env_ == Env::Default()) {
-    EnvOptions soptions;
-    soptions.use_direct_reads = soptions.use_direct_writes = direct_io_;
-    IoctlFriendlyTmpdir ift;
-    std::string fname = ift.name() + "/testfile";
-    unique_ptr<WritableFile> wfile;
-    ASSERT_OK(env_->NewWritableFile(fname, &wfile, soptions));
-
-    unique_ptr<RandomAccessFile> file;
-
-    // Get Unique ID
-    ASSERT_OK(env_->NewRandomAccessFile(fname, &file, soptions));
-    size_t id_size = file->GetUniqueId(temp_id, MAX_ID_SIZE);
-    ASSERT_TRUE(id_size > 0);
-    std::string unique_id1(temp_id, id_size);
-    ASSERT_TRUE(IsUniqueIDValid(unique_id1));
-
-    // Get Unique ID again
-    ASSERT_OK(env_->NewRandomAccessFile(fname, &file, soptions));
-    id_size = file->GetUniqueId(temp_id, MAX_ID_SIZE);
-    ASSERT_TRUE(id_size > 0);
-    std::string unique_id2(temp_id, id_size);
-    ASSERT_TRUE(IsUniqueIDValid(unique_id2));
-
-    // Get Unique ID again after waiting some time.
-    env_->SleepForMicroseconds(1000000);
-    ASSERT_OK(env_->NewRandomAccessFile(fname, &file, soptions));
-    id_size = file->GetUniqueId(temp_id, MAX_ID_SIZE);
-    ASSERT_TRUE(id_size > 0);
-    std::string unique_id3(temp_id, id_size);
-    ASSERT_TRUE(IsUniqueIDValid(unique_id3));
-
-    // Check IDs are the same.
-    ASSERT_EQ(unique_id1, unique_id2);
-    ASSERT_EQ(unique_id2, unique_id3);
-
-    // Delete the file
-    env_->DeleteFile(fname);
-  }
-}
-
 // only works in linux platforms
 #ifdef ROCKSDB_FALLOCATE_PRESENT
 TEST_P(EnvPosixTestWithParam, AllocateTest) {
@@ -842,104 +939,6 @@ TEST_P(EnvPosixTestWithParam, AllocateTest) {
   }
 }
 #endif  // ROCKSDB_FALLOCATE_PRESENT
-
-// Returns true if any of the strings in ss are the prefix of another string.
-bool HasPrefix(const std::unordered_set<std::string>& ss) {
-  for (const std::string& s: ss) {
-    if (s.empty()) {
-      return true;
-    }
-    for (size_t i = 1; i < s.size(); ++i) {
-      if (ss.count(s.substr(0, i)) != 0) {
-        return true;
-      }
-    }
-  }
-  return false;
-}
-
-// Only works in linux and WIN platforms
-TEST_P(EnvPosixTestWithParam, RandomAccessUniqueIDConcurrent) {
-  if (env_ == Env::Default()) {
-    // Check whether a bunch of concurrently existing files have unique IDs.
-    EnvOptions soptions;
-    soptions.use_direct_reads = soptions.use_direct_writes = direct_io_;
-
-    // Create the files
-    IoctlFriendlyTmpdir ift;
-    std::vector<std::string> fnames;
-    for (int i = 0; i < 1000; ++i) {
-      fnames.push_back(ift.name() + "/" + "testfile" + ToString(i));
-
-      // Create file.
-      unique_ptr<WritableFile> wfile;
-      ASSERT_OK(env_->NewWritableFile(fnames[i], &wfile, soptions));
-    }
-
-    // Collect and check whether the IDs are unique.
-    std::unordered_set<std::string> ids;
-    for (const std::string fname : fnames) {
-      unique_ptr<RandomAccessFile> file;
-      std::string unique_id;
-      ASSERT_OK(env_->NewRandomAccessFile(fname, &file, soptions));
-      size_t id_size = file->GetUniqueId(temp_id, MAX_ID_SIZE);
-      ASSERT_TRUE(id_size > 0);
-      unique_id = std::string(temp_id, id_size);
-      ASSERT_TRUE(IsUniqueIDValid(unique_id));
-
-      ASSERT_TRUE(ids.count(unique_id) == 0);
-      ids.insert(unique_id);
-    }
-
-    // Delete the files
-    for (const std::string fname : fnames) {
-      ASSERT_OK(env_->DeleteFile(fname));
-    }
-
-    ASSERT_TRUE(!HasPrefix(ids));
-  }
-}
-
-// Only works in linux and WIN platforms
-TEST_P(EnvPosixTestWithParam, RandomAccessUniqueIDDeletes) {
-  if (env_ == Env::Default()) {
-    EnvOptions soptions;
-    soptions.use_direct_reads = soptions.use_direct_writes = direct_io_;
-
-    IoctlFriendlyTmpdir ift;
-    std::string fname = ift.name() + "/" + "testfile";
-
-    // Check that after file is deleted we don't get same ID again in a new
-    // file.
-    std::unordered_set<std::string> ids;
-    for (int i = 0; i < 1000; ++i) {
-      // Create file.
-      {
-        unique_ptr<WritableFile> wfile;
-        ASSERT_OK(env_->NewWritableFile(fname, &wfile, soptions));
-      }
-
-      // Get Unique ID
-      std::string unique_id;
-      {
-        unique_ptr<RandomAccessFile> file;
-        ASSERT_OK(env_->NewRandomAccessFile(fname, &file, soptions));
-        size_t id_size = file->GetUniqueId(temp_id, MAX_ID_SIZE);
-        ASSERT_TRUE(id_size > 0);
-        unique_id = std::string(temp_id, id_size);
-      }
-
-      ASSERT_TRUE(IsUniqueIDValid(unique_id));
-      ASSERT_TRUE(ids.count(unique_id) == 0);
-      ids.insert(unique_id);
-
-      // Delete the file
-      ASSERT_OK(env_->DeleteFile(fname));
-    }
-
-    ASSERT_TRUE(!HasPrefix(ids));
-  }
-}
 
 // Only works in linux platforms
 #ifdef OS_WIN

--- a/env/io_posix.cc
+++ b/env/io_posix.cc
@@ -239,59 +239,6 @@ Status PosixSequentialFile::InvalidateCache(size_t offset, size_t length) {
 
 /*
  * PosixRandomAccessFile
- */
-#if defined(OS_LINUX)
-size_t PosixHelper::GetUniqueIdFromFile(int fd, char* id, size_t max_size) {
-  if (max_size < kMaxVarint64Length * 3) {
-    return 0;
-  }
-
-  struct stat buf;
-  int result = fstat(fd, &buf);
-  assert(result != -1);
-  if (result == -1) {
-    return 0;
-  }
-
-  long version = 0;
-  result = ioctl(fd, FS_IOC_GETVERSION, &version);
-  TEST_SYNC_POINT_CALLBACK("GetUniqueIdFromFile:FS_IOC_GETVERSION", &result);
-  if (result == -1) {
-    return 0;
-  }
-  uint64_t uversion = (uint64_t)version;
-
-  char* rid = id;
-  rid = EncodeVarint64(rid, buf.st_dev);
-  rid = EncodeVarint64(rid, buf.st_ino);
-  rid = EncodeVarint64(rid, uversion);
-  assert(rid >= id);
-  return static_cast<size_t>(rid - id);
-}
-#endif
-
-#if defined(OS_MACOSX) || defined(OS_AIX)
-size_t PosixHelper::GetUniqueIdFromFile(int fd, char* id, size_t max_size) {
-  if (max_size < kMaxVarint64Length * 3) {
-    return 0;
-  }
-
-  struct stat buf;
-  int result = fstat(fd, &buf);
-  if (result == -1) {
-    return 0;
-  }
-
-  char* rid = id;
-  rid = EncodeVarint64(rid, buf.st_dev);
-  rid = EncodeVarint64(rid, buf.st_ino);
-  rid = EncodeVarint64(rid, buf.st_gen);
-  assert(rid >= id);
-  return static_cast<size_t>(rid - id);
-}
-#endif
-/*
- * PosixRandomAccessFile
  *
  * pread() based random-access
  */
@@ -367,12 +314,6 @@ Status PosixRandomAccessFile::Prefetch(uint64_t offset, size_t n) {
   }
   return s;
 }
-
-#if defined(OS_LINUX) || defined(OS_MACOSX) || defined(OS_AIX)
-size_t PosixRandomAccessFile::GetUniqueId(char* id, size_t max_size) const {
-  return PosixHelper::GetUniqueIdFromFile(fd_, id, max_size);
-}
-#endif
 
 void PosixRandomAccessFile::Hint(AccessPattern pattern) {
   if (use_direct_io()) {
@@ -908,12 +849,6 @@ Status PosixWritableFile::RangeSync(uint64_t offset, uint64_t nbytes) {
                        " bytes " + ToString(nbytes),
                    filename_, errno);
   }
-}
-#endif
-
-#ifdef OS_LINUX
-size_t PosixWritableFile::GetUniqueId(char* id, size_t max_size) const {
-  return PosixHelper::GetUniqueIdFromFile(fd_, id, max_size);
 }
 #endif
 

--- a/env/io_posix.h
+++ b/env/io_posix.h
@@ -47,11 +47,6 @@ static Status IOError(const std::string& context, const std::string& file_name,
   }
 }
 
-class PosixHelper {
- public:
-  static size_t GetUniqueIdFromFile(int fd, char* id, size_t max_size);
-};
-
 class PosixSequentialFile : public SequentialFile {
  private:
   std::string filename_;
@@ -93,9 +88,6 @@ class PosixRandomAccessFile : public RandomAccessFile {
 
   virtual Status Prefetch(uint64_t offset, size_t n) override;
 
-#if defined(OS_LINUX) || defined(OS_MACOSX) || defined(OS_AIX)
-  virtual size_t GetUniqueId(char* id, size_t max_size) const override;
-#endif
   virtual void Hint(AccessPattern pattern) override;
   virtual Status InvalidateCache(size_t offset, size_t length) override;
   virtual bool use_direct_io() const override { return use_direct_io_; }
@@ -142,9 +134,6 @@ class PosixWritableFile : public WritableFile {
 #endif
 #ifdef ROCKSDB_RANGESYNC_PRESENT
   virtual Status RangeSync(uint64_t offset, uint64_t nbytes) override;
-#endif
-#ifdef OS_LINUX
-  virtual size_t GetUniqueId(char* id, size_t max_size) const override;
 #endif
 };
 

--- a/include/rocksdb/env.h
+++ b/include/rocksdb/env.h
@@ -502,6 +502,8 @@ class SequentialFile {
 
 // A file abstraction for randomly reading the contents of a file.
 class RandomAccessFile {
+ private:
+  std::string unique_id_;
  public:
 
   RandomAccessFile() { }
@@ -541,9 +543,17 @@ class RandomAccessFile {
   //
   // Note: these IDs are only valid for the duration of the process.
   virtual size_t GetUniqueId(char* id, size_t max_size) const {
-    return 0; // Default implementation to prevent issues with backwards
-              // compatibility.
-  };
+    if (max_size >= unique_id_.length()) {
+      memcpy(id, unique_id_.data(), unique_id_.length());
+      return unique_id_.length();
+    }
+    return 0;
+  }
+
+  // Sets a unique ID for this file that could be returned in GetUniqueId.
+  virtual void SetUniqueId(std::string unique_id) {
+    unique_id_ = std::move(unique_id);
+  }
 
   enum AccessPattern { NORMAL, RANDOM, SEQUENTIAL, WILLNEED, DONTNEED };
 
@@ -675,7 +685,16 @@ class WritableFile {
 
   // For documentation, refer to RandomAccessFile::GetUniqueId()
   virtual size_t GetUniqueId(char* id, size_t max_size) const {
-    return 0; // Default implementation to prevent issues with backwards
+    if (max_size >= unique_id_.length()) {
+      memcpy(id, unique_id_.data(), unique_id_.length());
+      return unique_id_.length();
+    }
+    return 0;
+  }
+
+  // Sets a unique ID for this file that could be returned in GetUniqueId.
+  virtual void SetUniqueId(std::string unique_id) {
+    unique_id_ = std::move(unique_id);
   }
 
   // Remove any kind of caching of data from the offset to offset+length
@@ -729,6 +748,7 @@ class WritableFile {
  private:
   size_t last_preallocated_block_;
   size_t preallocation_block_size_;
+  std::string unique_id_;
   // No copying allowed
   WritableFile(const WritableFile&);
   void operator=(const WritableFile&);
@@ -1131,6 +1151,9 @@ class WritableFileWrapper : public WritableFile {
   }
   size_t GetUniqueId(char* id, size_t max_size) const override {
     return target_->GetUniqueId(id, max_size);
+  }
+  void SetUniqueId(std::string unique_id) override {
+    target_->SetUniqueId(unique_id);
   }
   Status InvalidateCache(size_t offset, size_t length) override {
     return target_->InvalidateCache(offset, length);

--- a/port/win/io_win.h
+++ b/port/win/io_win.h
@@ -61,8 +61,6 @@ Status fallocate(const std::string& filename, HANDLE hFile, uint64_t to_size);
 
 Status ftruncate(const std::string& filename, HANDLE hFile, uint64_t toSize);
 
-size_t GetUniqueIdFromFile(HANDLE hFile, char* id, size_t max_size);
-
 class WinFileData {
  protected:
   const std::string filename_;
@@ -148,8 +146,6 @@ class WinMmapReadableFile : private WinFileData, public RandomAccessFile {
                       char* scratch) const override;
 
   virtual Status InvalidateCache(size_t offset, size_t length) override;
-
-  virtual size_t GetUniqueId(char* id, size_t max_size) const override;
 };
 
 // We preallocate and use memcpy to append new
@@ -230,8 +226,6 @@ class WinMmapFile : private WinFileData, public WritableFile {
   virtual Status InvalidateCache(size_t offset, size_t length) override;
 
   virtual Status Allocate(uint64_t offset, uint64_t len) override;
-
-  virtual size_t GetUniqueId(char* id, size_t max_size) const override;
 };
 
 class WinRandomAccessImpl {
@@ -273,8 +267,6 @@ class WinRandomAccessFile
 
   virtual Status Read(uint64_t offset, size_t n, Slice* result,
                       char* scratch) const override;
-
-  virtual size_t GetUniqueId(char* id, size_t max_size) const override;
 
   virtual bool use_direct_io() const override { return WinFileData::use_direct_io(); }
 
@@ -377,8 +369,6 @@ class WinWritableFile : private WinFileData,
   virtual uint64_t GetFileSize() override;
 
   virtual Status Allocate(uint64_t offset, uint64_t len) override;
-
-  virtual size_t GetUniqueId(char* id, size_t max_size) const override;
 };
 
 class WinRandomRWFile : private WinFileData,


### PR DESCRIPTION
Currently on POSIX, the cache key prefix for SST files is generated from the
inode number and its generation number, which is less unique on some
OSes/FSes than others. This change sets that key prefix based on a
passed in unique ID, which is composed of a table-cache-specific ID
plus the SST number. This should resolve issues around cache collisions
between two different SS tables that happened to have the same
generation number.

Backported from 19.2 release branch (crl-release-6.2.1).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/rocksdb/65)
<!-- Reviewable:end -->
