### PR TITLE
gcc9 fixes

### DIFF
--- a/db/internal_stats.h
+++ b/db/internal_stats.h
@@ -237,6 +237,8 @@ class InternalStats {
       }
     }
 
+    CompactionStats& operator=(const CompactionStats&) = default;
+
     void Clear() {
       this->micros = 0;
       this->cpu_micros = 0;
@@ -625,6 +627,8 @@ class InternalStats {
     explicit CompactionStats(CompactionReason /*reason*/, int /*c*/) {}
 
     explicit CompactionStats(const CompactionStats& /*c*/) {}
+
+    CompactionStats& operator=(const CompactionStats&) = default;
 
     void Add(const CompactionStats& /*c*/) {}
 

--- a/db/version_edit.h
+++ b/db/version_edit.h
@@ -61,6 +61,8 @@ struct FileDescriptor {
     return *this;
   }
 
+  constexpr FileDescriptor(const rocksdb::FileDescriptor&) = default;
+
   uint64_t GetNumber() const {
     return packed_number_and_path_id & kFileNumberMask;
   }


### PR DESCRIPTION
Introduce a copy constructor and assignment operator which were no
longer implicitly defined since C++11 (at least not with gcc 9.2.1
although apparently it works with at least some clang versions and with
gcc 7.4.0).

The language says:
Since C++11: The generation of the implicitly-defined copy constructor
is deprecated if T has a user-defined destructor or user-defined copy
assignment operator.
(and similar for the operator)

These are not the only problems compiling with gcc 9.2.1.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/rocksdb/68)
<!-- Reviewable:end -->
