### PR TITLE
scan subcompaction split point covered by range dels

### DIFF
--- a/table/block_based_table_reader.cc
+++ b/table/block_based_table_reader.cc
@@ -2025,8 +2025,10 @@ void BlockBasedTableIterator::FindKeyForward() {
       continue;
     }
     // The key is contained within the current tombstone.
-    if (range_tombstone_.seq() == 0) {
-      // The tombstone doesn't apply to the sstable. Return the entry.
+    if (range_tombstone_.seq() == 0 ||
+        icomp_.Compare(key(), tombstone_internal_end_key()) >= 0) {
+      // The tombstone doesn't apply to the current key or doesn't allow us to
+      // skip past it. Return the entry.
       return;
     }
 


### PR DESCRIPTION
Fix an infinite loop in range tombstone seek-to-end-key optimization. It
happened when a range tombstone was split according to its containing
files' boundaries. In particular, the split point had to have a lower
sequence number than a point key at the same user key in a file that the
range tombstone covered.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/rocksdb/71)
<!-- Reviewable:end -->
