### PR TITLE
db_impl_write: Remove extra "%s" in WAL switch failure log line

### DIFF
--- a/db/db_impl_write.cc
+++ b/db/db_impl_write.cc
@@ -1435,7 +1435,7 @@ Status DBImpl::SwitchMemtable(ColumnFamilyData* cfd, WriteContext* context) {
       if (!s.ok()) {
         ROCKS_LOG_WARN(immutable_db_options_.info_log,
                        "[%s] Failed to switch from #%" PRIu64 " to #%" PRIu64
-                       "  WAL file -- %s\n",
+                       "  WAL file\n",
                        cfd->GetName().c_str(), cur_log_writer->get_log_number(),
                        new_log_number);
       }


### PR DESCRIPTION
This extra %s was causing a segfault, resulting in synctest failing
because it exercised this condition.

Fixes https://github.com/cockroachdb/cockroach/issues/42778 .

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/rocksdb/73)
<!-- Reviewable:end -->
