### PR TITLE
Fix compile error due to '-march=native' option on ppc64le

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -198,6 +198,7 @@ if(CMAKE_SYSTEM_PROCESSOR MATCHES "ppc64le")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -maltivec")
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -mcpu=power8")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mcpu=power8")
+    set(HAVE_POWER8 "1")
   endif(HAS_ALTIVEC)
 endif(CMAKE_SYSTEM_PROCESSOR MATCHES "ppc64le")
 


### PR DESCRIPTION
Compilation failure on ppc64le with following error:
c++: error: unrecognized command line option '-march=native'
The issue was CMakeLists was not setting macro to indicate
ppc64le platform.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/rocksdb/76)
<!-- Reviewable:end -->
