### PR TITLE
util/channel.h: remove an invalid const specifier

### DIFF
--- a/util/channel.h
+++ b/util/channel.h
@@ -31,7 +31,7 @@ class channel {
     return buffer_.empty() && eof_;
   }
 
-  size_t size() const {
+  size_t size() {
     std::lock_guard<std::mutex> lk(lock_);
     return buffer_.size();
   }


### PR DESCRIPTION
This error was found by Clang 10.

Informs https://github.com/cockroachdb/cockroach/issues/46300

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/rocksdb/79)
<!-- Reviewable:end -->
