### PR TITLE
crl-release-5.13: fix correctness issue with snapshots and delete range

### DIFF
--- a/db/db_range_del_test.cc
+++ b/db/db_range_del_test.cc
@@ -1652,6 +1652,156 @@ TEST_F(DBRangeDelTest, RangeTombstoneWrittenToMinimalSsts) {
   ASSERT_EQ(1, num_range_deletions);
 }
 
+TEST_F(DBRangeDelTest, SnapshotRangeDelStress) {
+  const int kRuns = 1000;
+  const int kMiddleKey = kRuns * kRuns;
+
+  Options options = CurrentOptions();
+  options.compression = kNoCompression;
+  Reopen(options);
+
+  auto key = [&](int i) {
+    char buf[100];
+    snprintf(buf, sizeof(buf), "key%08d", i);
+    return std::string(buf);
+  };
+
+  std::vector<const Snapshot*> snapshots;
+  for (int r = 0; r < kRuns; ++r) {
+      // We use a keyspace that is 2*kRuns^2 wide. In other words there are
+      // 2*kRuns sections of the keyspace, each with kRuns elements. On every
+      // run, we write to the r-th element of each section of the keyspace.
+      for (int i = 0; i < 2 * kRuns; i++) {
+        ASSERT_OK(Put(key(kRuns * i + r), "a"));
+      }
+
+      // Now we delete some the keyspace through a DeleteRange. We delete from
+      // the middle of the keyspace outwards. Since the keyspace is made of
+      // 2*kRun sections, we delete an additional two of these sections per run.
+      ASSERT_OK(db_->DeleteRange(WriteOptions(), db_->DefaultColumnFamily(),
+                                 key(kMiddleKey - kRuns * r),
+                                 key(kMiddleKey + kRuns * r)));
+
+      snapshots.push_back(db_->GetSnapshot());
+  }
+
+  ASSERT_OK(dbfull()->TEST_SwitchMemtable());
+
+  int run = 0;
+  for (auto* snapshot : snapshots) {
+    // Count the keys at this snapshot.
+    ReadOptions read_opts;
+    read_opts.snapshot = snapshot;
+    auto* iter = db_->NewIterator(read_opts);
+    iter->SeekToFirst();
+    int keys_found = 0;
+    for (; iter->Valid(); iter->Next()) {
+      ++keys_found;
+    }
+    delete iter;
+
+    // At the time that this snapshot was taken, (run+1)*2*kRuns
+    // keys were set (one in each of the 2*kRuns sections per run).
+    // But this run also deleted the 2*run middlemost sections.
+    // At the time this snapshot ran, each of those sections had
+    // (run+1) keys populated, so we deleted 2*run*(run+1) keys
+    // with the delete range.
+    const int keys_expected = (run+1) * 2 * kRuns - 2*run*(run+1);
+    ASSERT_EQ(keys_expected, keys_found);
+
+    db_->ReleaseSnapshot(snapshot);
+    ++run;
+  }
+}
+
+TEST_F(DBRangeDelTest, SnapshotIgnoresNewerRangeDeletions) {
+  Options options = CurrentOptions();
+  options.compression = kNoCompression;
+  Reopen(options);
+
+  auto put =
+      [&](int i) {
+        auto k = Key(i);
+        ASSERT_OK(Put(k, "a"));
+      };
+  auto deleteRange =
+      [&](int start, int end) {
+        auto sk = Key(start);
+        auto ek = Key(end);
+        ASSERT_OK(db_->DeleteRange(WriteOptions(), db_->DefaultColumnFamily(), sk, ek));
+      };
+  auto check =
+      [&](const Snapshot *snapshot, const int expected) {
+        ReadOptions read_opts;
+        read_opts.snapshot = snapshot;
+        auto* iter = db_->NewIterator(read_opts);
+        int keys_found = 0;
+        for (iter->SeekToFirst(); iter->Valid(); iter->Next()) {
+          ++keys_found;
+        }
+        delete iter;
+        ASSERT_EQ(expected, keys_found);
+      };
+
+  put(0);
+  put(1);
+  put(2);
+  put(3);
+
+  auto snapshot = db_->GetSnapshot();
+  check(snapshot, 4);
+
+  deleteRange(0, 2);
+  check(snapshot, 4);
+
+  ASSERT_OK(db_->Flush(FlushOptions()));
+  check(snapshot, 4);
+
+  deleteRange(2, 4);
+  check(snapshot, 4);
+}
+
+TEST_F(DBRangeDelTest, SnapshotPreventsDroppedKeysInImmMemTables) {
+  const int kFileBytes = 1 << 20;
+
+  Options options = CurrentOptions();
+  options.compression = kNoCompression;
+  options.disable_auto_compactions = true;
+  options.target_file_size_base = kFileBytes;
+  Reopen(options);
+
+  // block flush thread -> pin immtables in memory
+  SyncPoint::GetInstance()->DisableProcessing();
+  SyncPoint::GetInstance()->LoadDependency({
+      {"SnapshotPreventsDroppedKeysInImmMemTables:AfterNewIterator",
+       "DBImpl::BGWorkFlush"},
+  });
+  SyncPoint::GetInstance()->EnableProcessing();
+
+  ASSERT_OK(Put(Key(0), "a"));
+  std::unique_ptr<const Snapshot, std::function<void(const Snapshot*)>>
+      snapshot(db_->GetSnapshot(),
+               [this](const Snapshot* s) { db_->ReleaseSnapshot(s); });
+
+  ASSERT_OK(db_->DeleteRange(WriteOptions(), db_->DefaultColumnFamily(), Key(0),
+                             Key(10)));
+
+  ASSERT_OK(dbfull()->TEST_SwitchMemtable());
+
+  ReadOptions read_opts;
+  read_opts.snapshot = snapshot.get();
+  std::unique_ptr<Iterator> iter(db_->NewIterator(read_opts));
+
+  TEST_SYNC_POINT("SnapshotPreventsDroppedKeysInImmMemTables:AfterNewIterator");
+
+  iter->SeekToFirst();
+  ASSERT_TRUE(iter->Valid());
+  ASSERT_EQ(Key(0), iter->key());
+
+  iter->Next();
+  ASSERT_FALSE(iter->Valid());
+}
+
 #endif  // ROCKSDB_LITE
 
 }  // namespace rocksdb

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -544,13 +544,17 @@ class LevelIterator final : public InternalIterator {
   InternalIterator* NewFileIterator() {
     assert(file_index_ < flevel_->num_files);
     auto file_meta = flevel_->files[file_index_];
+    // NOTE: this optimization is disabled as it has correctness issues
+    // when used with snapshot reads.
+    //
     // Check to see if every key in the sstable is covered by a range
     // tombstone. SkipEmptyFile{Forward,Backward} will take care of skipping
     // over an "empty" file if we return null.
-    if (range_del_agg_->ShouldDeleteRange(file_meta.smallest_key, file_meta.largest_key,
-                                          file_meta.file_metadata->largest_seqno)) {
-      return nullptr;
-    }
+    //
+    // if (range_del_agg_->ShouldDeleteRange(file_meta.smallest_key, file_meta.largest_key,
+    //                                       file_meta.file_metadata->largest_seqno)) {
+    //   return nullptr;
+    // }
 
     if (should_sample_) {
       sample_file_read_inc(file_meta.file_metadata);

--- a/table/block_based_table_reader.cc
+++ b/table/block_based_table_reader.cc
@@ -2133,32 +2133,35 @@ void BlockBasedTableIterator::FindKeyBackward() {
 }
 
 void BlockBasedTableIterator::InitRangeTombstone(const Slice& target) {
-  if (range_del_agg_ == nullptr || file_meta_ == nullptr) {
-    return;
-  }
+  // NOTE: this optimization is disabled as it has correctness issues
+  // when used with snapshot reads.
 
-  range_tombstone_ = range_del_agg_->GetTombstone(target, file_meta_->largest_seqno);
+  // if (range_del_agg_ == nullptr || file_meta_ == nullptr) {
+  //   return;
+  // }
 
-  // Clear the start key if it is less than the smallest key in the
-  // sstable. This allows us to avoid comparisons during Prev() in the common
-  // case.
-  if (range_tombstone_.start_key() != nullptr) {
-    ParsedInternalKey smallest;
-    if (!ParseInternalKey(file_meta_->smallest.Encode(), &smallest) ||
-        (icomp_.Compare(*range_tombstone_.start_key(), smallest) < 0)) {
-      range_tombstone_.SetStartKey(nullptr);
-    }
-  }
-  // Clear the end key if it is larger than the largest key in the
-  // sstable. This allows us to avoid comparisons during Next() in the common
-  // case.
-  if (range_tombstone_.end_key() != nullptr) {
-    ParsedInternalKey largest;
-    if (!ParseInternalKey(file_meta_->largest.Encode(), &largest) ||
-        (icomp_.Compare(*range_tombstone_.end_key(), largest) > 0)) {
-      range_tombstone_.SetEndKey(nullptr);
-    }
-  }
+  // range_tombstone_ = range_del_agg_->GetTombstone(target, file_meta_->largest_seqno);
+
+  // // Clear the start key if it is less than the smallest key in the
+  // // sstable. This allows us to avoid comparisons during Prev() in the common
+  // // case.
+  // if (range_tombstone_.start_key() != nullptr) {
+  //   ParsedInternalKey smallest;
+  //   if (!ParseInternalKey(file_meta_->smallest.Encode(), &smallest) ||
+  //       (icomp_.Compare(*range_tombstone_.start_key(), smallest) < 0)) {
+  //     range_tombstone_.SetStartKey(nullptr);
+  //   }
+  // }
+  // // Clear the end key if it is larger than the largest key in the
+  // // sstable. This allows us to avoid comparisons during Next() in the common
+  // // case.
+  // if (range_tombstone_.end_key() != nullptr) {
+  //   ParsedInternalKey largest;
+  //   if (!ParseInternalKey(file_meta_->largest.Encode(), &largest) ||
+  //       (icomp_.Compare(*range_tombstone_.end_key(), largest) > 0)) {
+  //     range_tombstone_.SetEndKey(nullptr);
+  //   }
+  // }
 }
 
 std::string BlockBasedTableIterator::tombstone_internal_start_key() const {


### PR DESCRIPTION
The optimization to skip sstables and swaths of keys within an sstable
covered by a range tombstone has correctness issues when used with
snapshot reads. This optimization isn't present in later versions of
RocksDB, so disable it rather than trying to fix.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/rocksdb/83)
<!-- Reviewable:end -->
