### PR TITLE
crl-release-5.17.2: fix correctness issue with snapshots and delete range

### DIFF
--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -540,13 +540,16 @@ class LevelIterator final : public InternalIterator {
   InternalIterator* NewFileIterator() {
     assert(file_index_ < flevel_->num_files);
     auto file_meta = flevel_->files[file_index_];
+    // NOTE: this optimization is disabled as it has correctness issues
+    // when used with snapshot reads.
+    //
     // Check to see if every key in the sstable is covered by a range
     // tombstone. SkipEmptyFile{Forward,Backward} will take care of skipping
     // over an "empty" file if we return null.
-    if (range_del_agg_->ShouldDeleteRange(file_meta.smallest_key, file_meta.largest_key,
-                                          file_meta.file_metadata->fd.largest_seqno)) {
-      return nullptr;
-    }
+    // if (range_del_agg_->ShouldDeleteRange(file_meta.smallest_key, file_meta.largest_key,
+    //                                       file_meta.file_metadata->fd.largest_seqno)) {
+    //   return nullptr;
+    // }
 
     if (should_sample_) {
       sample_file_read_inc(file_meta.file_metadata);

--- a/table/block_based_table_reader.cc
+++ b/table/block_based_table_reader.cc
@@ -1095,7 +1095,7 @@ Status BlockBasedTable::Open(const ImmutableCFOptions& ioptions,
     if (tail_prefetch_stats != nullptr) {
       assert(prefetch_buffer->min_offset_read() < file_size);
       tail_prefetch_stats->RecordEffectiveSize(
-				static_cast<size_t>(file_size) - prefetch_buffer->min_offset_read());
+                                static_cast<size_t>(file_size) - prefetch_buffer->min_offset_read());
     }
     *table_reader = std::move(new_table);
   }
@@ -2370,33 +2370,36 @@ void BlockBasedTableIterator<TBlockIter, TValue>::FindKeyBackward() {
 }
 
 template <class TBlockIter, typename TValue>
-void BlockBasedTableIterator<TBlockIter, TValue>::InitRangeTombstone(const Slice& target) {
-  if (range_del_agg_ == nullptr || file_meta_ == nullptr) {
-    return;
-  }
+void BlockBasedTableIterator<TBlockIter, TValue>::InitRangeTombstone(const Slice& /* target */) {
+  // NOTE: this optimization is disabled as it has correctness issues
+  // when used with snapshot reads.
 
-  range_tombstone_ = range_del_agg_->GetTombstone(target, file_meta_->fd.largest_seqno);
+  // if (range_del_agg_ == nullptr || file_meta_ == nullptr) {
+  //   return;
+  // }
 
-  // Clear the start key if it is less than the smallest key in the
-  // sstable. This allows us to avoid comparisons during Prev() in the common
-  // case.
-  if (range_tombstone_.start_key() != nullptr) {
-    ParsedInternalKey smallest;
-    if (!ParseInternalKey(file_meta_->smallest.Encode(), &smallest) ||
-        (icomp_.Compare(*range_tombstone_.start_key(), smallest) < 0)) {
-      range_tombstone_.SetStartKey(nullptr);
-    }
-  }
-  // Clear the end key if it is larger than the largest key in the
-  // sstable. This allows us to avoid comparisons during Next() in the common
-  // case.
-  if (range_tombstone_.end_key() != nullptr) {
-    ParsedInternalKey largest;
-    if (!ParseInternalKey(file_meta_->largest.Encode(), &largest) ||
-        (icomp_.Compare(*range_tombstone_.end_key(), largest) > 0)) {
-      range_tombstone_.SetEndKey(nullptr);
-    }
-  }
+  // range_tombstone_ = range_del_agg_->GetTombstone(target, file_meta_->fd.largest_seqno);
+
+  // // Clear the start key if it is less than the smallest key in the
+  // // sstable. This allows us to avoid comparisons during Prev() in the common
+  // // case.
+  // if (range_tombstone_.start_key() != nullptr) {
+  //   ParsedInternalKey smallest;
+  //   if (!ParseInternalKey(file_meta_->smallest.Encode(), &smallest) ||
+  //       (icomp_.Compare(*range_tombstone_.start_key(), smallest) < 0)) {
+  //     range_tombstone_.SetStartKey(nullptr);
+  //   }
+  // }
+  // // Clear the end key if it is larger than the largest key in the
+  // // sstable. This allows us to avoid comparisons during Next() in the common
+  // // case.
+  // if (range_tombstone_.end_key() != nullptr) {
+  //   ParsedInternalKey largest;
+  //   if (!ParseInternalKey(file_meta_->largest.Encode(), &largest) ||
+  //       (icomp_.Compare(*range_tombstone_.end_key(), largest) > 0)) {
+  //     range_tombstone_.SetEndKey(nullptr);
+  //   }
+  // }
 }
 
 template <class TBlockIter, typename TValue>


### PR DESCRIPTION
The optimization to skip sstables and swaths of keys within an sstable
covered by a range tombstone has correctness issues when used with
snapshot reads. This optimization isn't present in later versions of
RocksDB, so disable it rather than trying to fix.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/rocksdb/84)
<!-- Reviewable:end -->
