### PR TITLE
RocksDB Cmake changes for Arm64 CRC32 Optimization (#5304)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -202,6 +202,15 @@ if(CMAKE_SYSTEM_PROCESSOR MATCHES "ppc64le")
   endif(HAS_ALTIVEC)
 endif(CMAKE_SYSTEM_PROCESSOR MATCHES "ppc64le")
 
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|AARCH64")
+        CHECK_C_COMPILER_FLAG("-march=armv8-a+crc" HAS_ARMV8_CRC)
+  if(HAS_ARMV8_CRC)
+    message(STATUS " HAS_ARMV8_CRC yes")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -march=armv8-a+crc -Wno-unused-function")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=armv8-a+crc -Wno-unused-function")
+  endif(HAS_ARMV8_CRC)
+endif(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|AARCH64")
+
 option(PORTABLE "build a portable binary" OFF)
 option(FORCE_SSE42 "force building with SSE4.2, even when PORTABLE=ON" OFF)
 if(PORTABLE)
@@ -214,7 +223,7 @@ else()
   if(MSVC)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /arch:AVX2")
   else()
-    if(NOT HAVE_POWER8)
+    if(NOT HAVE_POWER8 AND NOT HAS_ARMV8_CRC)
       set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native")
     endif()
   endif()
@@ -696,6 +705,11 @@ if(HAVE_POWER8)
     util/crc32c_ppc.c
     util/crc32c_ppc_asm.S)
 endif(HAVE_POWER8)
+
+if(HAS_ARMV8_CRC)
+  list(APPEND SOURCES
+    util/crc32c_arm64.cc)
+endif(HAS_ARMV8_CRC)
 
 if(WIN32)
   list(APPEND SOURCES


### PR DESCRIPTION
This is a direct copy of the changes included in https://github.com/facebook/rocksdb/pull/5304

When this is merged; the issue described at https://forum.cockroachlabs.com/t/failing-make-build-of-20-1-0-source-on-ubuntu-20-04-arm64/3701/11 is resolved - cockroachdb build successfully on Arm64 machines.

I understand that Arm64 may not be an officially supported architecture, however the patch here is very small and would allow the community to build cockroachdb without changes to the source and without modifications that effect other architectures. The patch has been merged in facebook's rocksdb repo since May 15, 2019.

All credit to @guyuqi for their work on the original patch.

Original commit message follows:

Summary:
Add CMake build for RocksDB CRC32 Optimization on Arm64.
Pull Request resolved: https://github.com/facebook/rocksdb/pull/5304

Differential Revision: D15355193

Pulled By: miasantreble

fbshipit-source-id: 8d750a444274fbde14e510f51290631a369026b8

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/rocksdb/85)
<!-- Reviewable:end -->
