### PR TITLE
util: elide usage of __DATE__

### DIFF
--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -3369,7 +3369,6 @@ void DumpRocksDBBuildVersion(Logger* log) {
   ROCKS_LOG_HEADER(log, "RocksDB version: %d.%d.%d\n", ROCKSDB_MAJOR,
                    ROCKSDB_MINOR, ROCKSDB_PATCH);
   ROCKS_LOG_HEADER(log, "Git sha %s", rocksdb_build_git_sha);
-  ROCKS_LOG_HEADER(log, "Compile date %s", rocksdb_build_compile_date);
 #else
   (void)log;  // ignore "-Wunused-parameter"
 #endif

--- a/util/build_version.cc.in
+++ b/util/build_version.cc.in
@@ -2,4 +2,3 @@
 #include "build_version.h"
 const char* rocksdb_build_git_sha = "rocksdb_build_git_sha:@@GIT_SHA@@";
 const char* rocksdb_build_git_date = "rocksdb_build_git_date:@@GIT_DATE_TIME@@";
-const char* rocksdb_build_compile_date = __DATE__;

--- a/util/build_version.h
+++ b/util/build_version.h
@@ -9,7 +9,4 @@
 // generate these variables
 // this variable tells us about the git revision
 extern const char* rocksdb_build_git_sha;
-
-// Date on which the code was compiled:
-extern const char* rocksdb_build_compile_date;
 #endif


### PR DESCRIPTION
Due to https://github.com/bazelbuild/rules_foreign_cc/issues/239, we
elide usage of `__DATE__` in RocksDB. It makes our life much easier when
trying to bazel-ify the cockroachdb repo.

(I'm aware we're in the process of removing RocksDB, but bear with me).
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/rocksdb/88)
<!-- Reviewable:end -->
